### PR TITLE
perp-1217 | faucet can ensure gas coin allowance

### DIFF
--- a/contracts/faucet/src/state.rs
+++ b/contracts/faucet/src/state.rs
@@ -7,6 +7,7 @@ mod trading_competition;
 pub use trading_competition::*;
 pub(crate) mod tokens;
 use cosmwasm_std::{Api, Deps, DepsMut, Empty, Env, QuerierWrapper, Storage};
+pub(crate) mod gas_coin;
 
 pub(crate) struct State<'a> {
     pub(crate) api: &'a dyn Api,

--- a/contracts/faucet/src/state/gas_coin.rs
+++ b/contracts/faucet/src/state/gas_coin.rs
@@ -1,0 +1,22 @@
+use msg::contracts::faucet::entry::GasAllowance;
+
+use super::*;
+
+const GAS_ALLOWANCE: Item<GasAllowance> = Item::new("gas-allowance");
+
+pub(crate) fn get_gas_allowance(store: &dyn Storage) -> Result<Option<GasAllowance>> {
+    GAS_ALLOWANCE.may_load(store).map_err(|e| e.into())
+}
+
+pub(crate) fn set_gas_allowance(
+    store: &mut dyn Storage,
+    gas_allowance: &GasAllowance,
+) -> Result<()> {
+    GAS_ALLOWANCE
+        .save(store, gas_allowance)
+        .map_err(|e| e.into())
+}
+
+pub(crate) fn clear_gas_allowance(store: &mut dyn Storage) {
+    GAS_ALLOWANCE.remove(store);
+}

--- a/packages/msg/src/contracts/faucet/entry.rs
+++ b/packages/msg/src/contracts/faucet/entry.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 use shared::prelude::*;
 
 use crate::contracts::cw20::Cw20Coin;
@@ -10,6 +10,8 @@ pub struct InstantiateMsg {
     pub tap_limit: Option<u32>,
     /// Code ID of the CW20 contract we'll deploy
     pub cw20_code_id: u64,
+    /// Configuration of the gas coin allowance
+    pub gas_allowance: Option<GasAllowance>,
 }
 
 #[cw_serde]
@@ -73,6 +75,10 @@ pub enum OwnerMsg {
         cw20: String,
         balances: Vec<Cw20Coin>,
     },
+    SetGasAllowance {
+        allowance: GasAllowance,
+    },
+    ClearGasAllowance {},
 }
 
 #[cw_serde]
@@ -98,6 +104,10 @@ pub enum QueryMsg {
     /// * returns [NextTradingIndexResponse]
     #[returns(NextTradingIndexResponse)]
     NextTradingIndex { name: String },
+
+    /// * returns [GasAllowanceResp]
+    #[returns(GasAllowanceResp)]
+    GetGasAllowance {},
 }
 
 #[cw_serde]
@@ -120,4 +130,16 @@ pub struct ConfigResponse {
     pub admins: Vec<Addr>,
     /// Given in seconds
     pub tap_limit: Option<u32>,
+}
+
+#[cw_serde]
+pub struct GasAllowance {
+    pub denom: String,
+    pub amount: Uint128,
+}
+
+#[cw_serde]
+pub enum GasAllowanceResp {
+    Enabled { denom: String, amount: Uint128 },
+    Disabled {},
 }

--- a/packages/perps-exes/src/bin/perps-bots/endpoints/faucet.rs
+++ b/packages/perps-exes/src/bin/perps-bots/endpoints/faucet.rs
@@ -95,6 +95,7 @@ async fn bot_inner(app: &App, query: FaucetQuery) -> Result<FaucetResponse> {
                     .cw20s
                     .into_iter()
                     .map(|x| FaucetAsset::Cw20(x.get_address_string().into()))
+                    // This will end up as a no-op if the faucet gas a gas allowance set.
                     .chain(std::iter::once(FaucetAsset::Native(
                         app.cosmos.get_gas_coin().clone(),
                     )))


### PR DESCRIPTION
This is for our Sei faucet deployment. We want to provide a much smaller amount of gas on Sei (since we have a limited supply). Therefore, I've added a new concept called the "gas allowance" to the faucet. It will only top off gas up until the allowance level, which when deploying to Sei I've already set to 1 SEI.