### PR TITLE
PERP-1170 | remove hatch id from nft attributes

### DIFF
--- a/contracts/hatching/src/state/ibc.rs
+++ b/contracts/hatching/src/state/ibc.rs
@@ -96,12 +96,16 @@ impl State<'_> {
             // get the hatch id from the first minted NFT. They're all the same
             match from_binary::<NftExecuteMsg>(first_message)? {
                 NftExecuteMsg::Mint(msg) => {
-                    self.update_hatch_status(ctx, msg.extract_hatch_id()?, |mut status| {
+                    let hatch_id = self.get_hatch_id_from_token_id(ctx.storage, &msg.token_id)?;
+                    self.update_hatch_status(ctx, hatch_id, |mut status| {
                         status.nft_mint_completed = true;
                         Ok(status)
                     })?;
                 }
             }
+
+            // NOTE: we could clear all the token id -> hatch id mappings here, but it's not necessary
+            // and preserving it could possibly be useful for debugging
         } else if let Ok(msg) = from_binary::<IbcExecuteMsg>(&ack.original_packet.data) {
             match msg {
                 IbcExecuteMsg::GrantLvn { hatch_id, .. } => {

--- a/packages/perps-exes/src/bin/rewards-test/cli.rs
+++ b/packages/perps-exes/src/bin/rewards-test/cli.rs
@@ -47,14 +47,14 @@ pub(crate) struct HatchEggOpt {
     #[clap(
         long,
         env = "HATCH_ADDRESS",
-        default_value = "juno1z5l48ekcdda6m34e6lclx98vxvj40frxaym50fc6v0gz43u4d35sdx5vur"
+        default_value = "juno17hgh0p226hl0h8c77nl4p6d4jhkgwdxznrht27gzyekkgrprsh6qsx4fn4"
     )]
     pub hatch_address: Address,
     // this is the address for the NFT minting itself (i.e. Levana Baby Dragons), not the ibc execute proxy contract
     #[clap(
         long,
         env = "NFT_MINT_ADDRESS",
-        default_value = "stars16p8642y87m0sefc37t4fl4sprmasxcn774wc9m558p80afpl03us70mr4j"
+        default_value = "stars167awkhtm96aelu0t2gcls723ar4guclnxf5x636fdlfdms0gvyxqkgxlpe"
     )]
     pub nft_mint_address: Address,
 


### PR DESCRIPTION
also ran an on-chain test with new contracts to make sure it all still works