### PR TITLE
perp-1228 | utilization bot calculates correct deposit collateral

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/app/utilization.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/utilization.rs
@@ -251,9 +251,8 @@ fn counter_to_deposit(
                     );
                 }
 
-                let deposit = counter
-                    .into_number()
-                    .checked_div(leverage_notional.into_number().abs())?;
+                let deposit = (counter.into_number() * max_gains_multiple)
+                    .checked_div(max_gains_in_notional.into_number())?;
 
                 NonZero::<Collateral>::try_from_number(deposit).with_context(|| {
                     format!("Calculated an invalid deposit collateral: {deposit}")


### PR DESCRIPTION
@lvn-reef-dragon I have one FIXME below, I _think_ I need to change the calculation for deriving deposit collateral from max gains to use notional leverage, can you let me know your thoughts?