### PR TITLE
Fix loading of overrides in bots

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/app/factory.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/factory.rs
@@ -11,8 +11,8 @@ use msg::{
     },
     token::Token,
 };
-use perps_exes::config::DeploymentConfig;
 
+use crate::config::BotConfig;
 use crate::watcher::{Heartbeat, WatchedTask, WatchedTaskOutput};
 
 use super::{App, AppBuilder};
@@ -65,10 +65,7 @@ async fn update(app: &App) -> Result<WatchedTaskOutput> {
     Ok(output)
 }
 
-pub(crate) async fn get_factory_info(
-    cosmos: &Cosmos,
-    config: &DeploymentConfig,
-) -> Result<FactoryInfo> {
+pub(crate) async fn get_factory_info(cosmos: &Cosmos, config: &BotConfig) -> Result<FactoryInfo> {
     let (factory, gitrev) = get_contract(cosmos, config, "factory")
         .await
         .context("Unable to get 'factory' contract")?;
@@ -88,7 +85,7 @@ pub(crate) async fn get_factory_info(
 
 pub(crate) async fn get_contract(
     cosmos: &Cosmos,
-    config: &DeploymentConfig,
+    config: &BotConfig,
     contract_type: &str,
 ) -> Result<(Address, Option<String>)> {
     let tracker = cosmos.make_contract(config.tracker);

--- a/packages/perps-exes/src/bin/perps-bots/app/trader.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/trader.rs
@@ -7,7 +7,10 @@ use msg::{contracts::market::entry::StatusResp, prelude::*};
 use perps_exes::prelude::*;
 use rand::Rng;
 
-use crate::watcher::{WatchedTaskOutput, WatchedTaskPerMarket};
+use crate::{
+    config::BotConfig,
+    watcher::{WatchedTaskOutput, WatchedTaskPerMarket},
+};
 
 use super::{factory::FactoryInfo, App, AppBuilder};
 
@@ -43,7 +46,7 @@ pub(crate) struct EnsureCollateral<'a> {
     pub(crate) market: &'a MarketContract,
     pub(crate) wallet: &'a Wallet,
     pub(crate) status: &'a StatusResp,
-    pub(crate) config: &'a DeploymentConfig,
+    pub(crate) config: &'a BotConfig,
     pub(crate) cosmos: &'a Cosmos,
     pub(crate) min: Collateral,
     pub(crate) to_mint: Collateral,

--- a/packages/perps-exes/src/bin/perps-bots/cli.rs
+++ b/packages/perps-exes/src/bin/perps-bots/cli.rs
@@ -1,10 +1,8 @@
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr};
 
 use anyhow::{Context, Result};
-use cosmos::{AddressType, CosmosNetwork, HasAddressType, SeedPhrase, Wallet};
+use cosmos::{AddressType, SeedPhrase, Wallet};
 use perps_exes::build_version;
-use perps_exes::config::{ChainConfig, Config, DeploymentConfig};
-use perps_exes::wallet_manager::WalletManager;
 
 #[derive(clap::Parser)]
 #[clap(version = build_version())]
@@ -91,96 +89,8 @@ impl Opt {
             wallet
         })
     }
-
-    pub(crate) fn parse_deployment(&self) -> Result<(CosmosNetwork, &str)> {
-        const NETWORKS: &[(CosmosNetwork, &str)] = &[
-            (CosmosNetwork::OsmosisTestnet, "osmo"),
-            (CosmosNetwork::Dragonfire, "dragon"),
-            (CosmosNetwork::SeiTestnet, "sei"),
-        ];
-        for (network, prefix) in NETWORKS {
-            if let Some(suffix) = self.deployment.strip_prefix(prefix) {
-                return Ok((*network, suffix));
-            }
-        }
-        Err(anyhow::anyhow!(
-            "Could not parse deployment: {}",
-            self.deployment
-        ))
-    }
 }
 
 fn get_env(key: &str) -> Result<String> {
     std::env::var(key).with_context(|| format!("Unable to load enviornment variable {key}"))
-}
-
-pub(crate) fn get_deployment_config(
-    config: &'static Config,
-    opt: &Opt,
-) -> Result<DeploymentConfig> {
-    let (network, suffix) = opt.parse_deployment()?;
-    let wallet_phrase_name = suffix.to_ascii_uppercase();
-    let partial_config = config
-        .deployments
-        .get(suffix)
-        .with_context(|| {
-            format!(
-                "No config found for {}. Valid configs: {}",
-                suffix,
-                config
-                    .deployments
-                    .keys()
-                    .map(|s| s.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        })?
-        .clone();
-    let ChainConfig {
-        tracker,
-        faucet,
-        explorer,
-        pyth,
-        watcher,
-        min_gas,
-        min_gas_in_faucet,
-        min_gas_in_gas_wallet,
-    } = config
-        .chains
-        .get(&network)
-        .with_context(|| format!("No chain config found for network {}", network))?;
-    Ok(DeploymentConfig {
-        tracker: *tracker,
-        faucet: *faucet,
-        pyth: pyth.clone(),
-        min_gas: *min_gas,
-        min_gas_in_faucet: *min_gas_in_faucet,
-        min_gas_in_gas_wallet: *min_gas_in_gas_wallet,
-        price_api: &config.price_api,
-        explorer,
-        contract_family: opt.deployment.clone(),
-        network,
-        crank_wallet: opt.get_crank_wallet(network.get_address_type(), &wallet_phrase_name)?,
-        price_wallet: if partial_config.price {
-            Some(Arc::new(opt.get_wallet(
-                network.get_address_type(),
-                &wallet_phrase_name,
-                "PRICE",
-            )?))
-        } else {
-            None
-        },
-        wallet_manager: WalletManager::new(
-            opt.get_wallet_seed(&wallet_phrase_name, "WALLET_MANAGER")?,
-            network.get_address_type(),
-        )?,
-        balance: partial_config.balance,
-        liquidity: partial_config.liquidity,
-        utilization: partial_config.utilization,
-        traders: partial_config.traders,
-        liquidity_config: config.liquidity.clone(),
-        utilization_config: config.utilization,
-        trader_config: config.trader,
-        watcher: watcher.clone(),
-    })
 }

--- a/packages/perps-exes/src/bin/perps-bots/config.rs
+++ b/packages/perps-exes/src/bin/perps-bots/config.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use cosmos::{Address, CosmosNetwork, HasAddressType, Wallet};
+use perps_exes::{
+    config::{
+        ChainConfig, Config, DeploymentInfo, LiquidityConfig, PythChainConfig, TraderConfig,
+        UtilizationConfig, WatcherConfig,
+    },
+    prelude::*,
+    wallet_manager::WalletManager,
+};
+
+use crate::cli::Opt;
+
+pub(crate) struct BotConfig {
+    pub(crate) tracker: Address,
+    pub(crate) faucet: Address,
+    pub(crate) pyth: Option<PythChainConfig>,
+    pub(crate) min_gas: u128,
+    pub(crate) min_gas_in_faucet: u128,
+    pub(crate) min_gas_in_gas_wallet: u128,
+    pub(crate) price_api: &'static str,
+    pub(crate) explorer: &'static str,
+    pub(crate) contract_family: String,
+    pub(crate) network: CosmosNetwork,
+    pub(crate) price_wallet: Option<Arc<Wallet>>,
+    pub(crate) crank_wallet: Wallet,
+    pub(crate) wallet_manager: WalletManager,
+    pub(crate) liquidity: bool,
+    pub(crate) utilization: bool,
+    pub(crate) balance: bool,
+    pub(crate) traders: usize,
+    pub(crate) liquidity_config: LiquidityConfig,
+    pub(crate) utilization_config: UtilizationConfig,
+    pub(crate) trader_config: TraderConfig,
+    pub(crate) watcher: WatcherConfig,
+}
+
+impl Opt {
+    pub(crate) fn get_bot_config(&self) -> Result<BotConfig> {
+        let config = Config::load()?;
+        let DeploymentInfo {
+            config: partial,
+            network,
+            wallet_phrase_name,
+        } = config.get_deployment_info(&self.deployment)?;
+        let ChainConfig {
+            tracker,
+            faucet,
+            explorer,
+            pyth,
+            watcher,
+            min_gas,
+            min_gas_in_faucet,
+            min_gas_in_gas_wallet,
+        } = config
+            .chains
+            .get(&network)
+            .with_context(|| format!("No chain config found for network {}", network))?;
+        Ok(BotConfig {
+            tracker: *tracker,
+            faucet: *faucet,
+            pyth: pyth.clone(),
+            min_gas: *min_gas,
+            min_gas_in_faucet: *min_gas_in_faucet,
+            min_gas_in_gas_wallet: *min_gas_in_gas_wallet,
+            price_api: &config.price_api,
+            explorer,
+            contract_family: self.deployment.clone(),
+            network,
+            crank_wallet: self.get_crank_wallet(network.get_address_type(), &wallet_phrase_name)?,
+            price_wallet: if partial.price {
+                Some(Arc::new(self.get_wallet(
+                    network.get_address_type(),
+                    &wallet_phrase_name,
+                    "PRICE",
+                )?))
+            } else {
+                None
+            },
+            wallet_manager: WalletManager::new(
+                self.get_wallet_seed(&wallet_phrase_name, "WALLET_MANAGER")?,
+                network.get_address_type(),
+            )?,
+            balance: partial.balance,
+            liquidity: partial.liquidity,
+            utilization: partial.utilization,
+            traders: partial.traders,
+            liquidity_config: config.liquidity.clone(),
+            utilization_config: config.utilization,
+            trader_config: config.trader,
+            watcher: watcher.clone(),
+        })
+    }
+}

--- a/packages/perps-exes/src/bin/perps-bots/main.rs
+++ b/packages/perps-exes/src/bin/perps-bots/main.rs
@@ -7,6 +7,7 @@ use tower_http::cors::CorsLayer;
 
 mod app;
 mod cli;
+pub(crate) mod config;
 mod endpoints;
 mod util;
 pub(crate) mod watcher;

--- a/packages/perps-exes/src/bin/perps-bots/util/markets.rs
+++ b/packages/perps-exes/src/bin/perps-bots/util/markets.rs
@@ -1,8 +1,9 @@
 use cosmos::{Address, Contract, Cosmos, HasAddress, Wallet};
 use msg::contracts::factory::entry::{MarketInfoResponse, MarketsResp};
 use msg::prelude::*;
-use perps_exes::config::DeploymentConfig;
 use std::fmt::Debug;
+
+use crate::config::BotConfig;
 
 use super::oracle::Pyth;
 
@@ -84,7 +85,7 @@ impl Market {
         &self,
         wallet: &Wallet,
         cosmos: &Cosmos,
-        config: &DeploymentConfig,
+        config: &BotConfig,
     ) -> Result<PriceApi> {
         let Self {
             price_admin,

--- a/packages/perps-exes/src/bin/perps-bots/util/oracle.rs
+++ b/packages/perps-exes/src/bin/perps-bots/util/oracle.rs
@@ -8,8 +8,9 @@ use msg::{
     },
     prelude::*,
 };
-use perps_exes::config::DeploymentConfig;
 use pyth_sdk_cw::PriceIdentifier;
+
+use crate::config::BotConfig;
 
 #[derive(Clone)]
 pub(crate) struct Pyth {
@@ -39,7 +40,7 @@ impl std::fmt::Debug for Pyth {
 impl Pyth {
     pub async fn new(
         cosmos: &Cosmos,
-        config: &DeploymentConfig,
+        config: &BotConfig,
         bridge_addr: Address,
         market_id: MarketId,
     ) -> Result<Self> {

--- a/packages/perps-exes/src/bin/perps-deploy/app.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/app.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use cosmos::{Address, Cosmos, CosmosNetwork, HasAddress, HasAddressType, Wallet};
 use msg::contracts::pyth_bridge::PythMarketPriceFeeds;
 use msg::prelude::MarketId;
-use perps_exes::config::{ChainConfig, Config, PartialDeploymentConfig};
+use perps_exes::config::{ChainConfig, Config, DeploymentConfig};
 
 use crate::{cli::Opt, faucet::Faucet, tracker::Tracker};
 
@@ -60,25 +60,18 @@ impl Opt {
     }
 
     pub(crate) async fn load_app(&self, family: &str) -> Result<App> {
-        let (suffix, network) = get_suffix_network(family)?;
-        let basic = self.load_basic_app(network).await?;
-
         let config = Config::load()?;
-        let partial_deploy_config = match config.overrides.get(family) {
-            Some(x) => x,
-            None => config.deployments.get(suffix).with_context(|| {
-                format!("No configuration for family {suffix}, user parameter was {family}")
-            })?,
-        };
+        let partial = config.get_deployment_info(family)?;
+        let basic = self.load_basic_app(partial.network).await?;
 
-        let PartialDeploymentConfig {
+        let DeploymentConfig {
             wallet_manager_address,
             price_address: price_admin,
             trading_competition,
             dev_settings,
             default_market_ids,
             ..
-        } = partial_deploy_config;
+        } = partial.config;
 
         let (tracker, faucet) = basic.get_tracker_faucet()?;
 
@@ -110,14 +103,14 @@ impl Opt {
         };
 
         Ok(App {
-            wallet_manager: wallet_manager_address.for_chain(network.get_address_type()),
-            price_admin: price_admin.for_chain(network.get_address_type()),
-            trading_competition: *trading_competition,
-            dev_settings: *dev_settings,
+            wallet_manager: wallet_manager_address.for_chain(partial.network.get_address_type()),
+            price_admin: price_admin.for_chain(partial.network.get_address_type()),
+            trading_competition,
+            dev_settings,
             tracker,
             faucet,
             basic,
-            default_market_ids: default_market_ids.clone(),
+            default_market_ids,
             pyth_info,
         })
     }

--- a/packages/perps-exes/src/prelude.rs
+++ b/packages/perps-exes/src/prelude.rs
@@ -1,4 +1,4 @@
+pub use crate::contracts::MarketContract;
 pub use crate::discovery::ConnectionInfo;
 pub use crate::PerpApp;
-pub use crate::{config::DeploymentConfig, contracts::MarketContract};
 pub use msg::prelude::*;


### PR DESCRIPTION
Previously there were two codepaths for loading up PartialDeploymentConfig information, and two different ways of parsing deployment strings. The code is now properly unified, and DeploymentConfig has been renamed to BotConfig and lives within the perps-bots codebase, as it should.