### PR TITLE
perp-1264 | position ID in PositionAction

### DIFF
--- a/contracts/market/src/state/history/trade.rs
+++ b/contracts/market/src/state/history/trade.rs
@@ -88,6 +88,7 @@ impl State<'_> {
         old_owner: Addr,
     ) -> Result<()> {
         let action = PositionAction {
+            id: Some(pos.id),
             kind: PositionActionKind::Transfer,
             timestamp: self.now(),
             collateral: pos.active_collateral.raw(),
@@ -236,6 +237,7 @@ impl State<'_> {
         let trade_fee_usd = trading_fee.map(|x| price_point.collateral_to_usd(x));
 
         let action = PositionAction {
+            id: Some(pos.id),
             kind,
             timestamp: self.now(),
             collateral: pos.active_collateral.raw(),
@@ -273,6 +275,7 @@ impl State<'_> {
         price_point: &PricePoint,
     ) -> Result<()> {
         let action = PositionAction {
+            id: Some(pos.id),
             kind: PositionActionKind::Close,
             timestamp: self.now(),
             collateral: active_collateral,

--- a/packages/msg/src/contracts/market/entry.rs
+++ b/packages/msg/src/contracts/market/entry.rs
@@ -595,6 +595,10 @@ pub struct TraderActionHistoryResp {
 /// A distinct position history action
 #[cw_serde]
 pub struct PositionAction {
+    /// ID of the position impacted
+    ///
+    /// For ease of migration, we allow for a missing position ID.
+    pub id: Option<PositionId>,
     /// Kind of action taken by the trader
     pub kind: PositionActionKind,
     /// Timestamp when the action occurred

--- a/packages/msg/src/contracts/market/history.rs
+++ b/packages/msg/src/contracts/market/history.rs
@@ -141,9 +141,11 @@ pub mod events {
         type Error = anyhow::Error;
 
         fn try_from(evt: Event) -> anyhow::Result<Self> {
+            let pos_id = PositionId::new(evt.u64_attr(event_key::POS_ID)?);
             Ok(PositionActionEvent {
-                pos_id: PositionId::new(evt.u64_attr(event_key::POS_ID)?),
+                pos_id,
                 action: PositionAction {
+                    id: Some(pos_id),
                     kind: evt.map_attr_result(event_key::POSITION_ACTION_KIND, |s| match s {
                         "open" => Ok(PositionActionKind::Open),
                         "update" => Ok(PositionActionKind::Update),


### PR DESCRIPTION
This is somewhat redundant for the position history API calls, but very useful in the trader history calls.

In the future we can consider removing the Option wrapping. It's only present for easier migration.