### PR TITLE
perp-1324 | congestion workarounds

### DIFF
--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -7,7 +7,7 @@ use crate::state::{
     fees::fees_init,
     liquidity::{liquidity_init, yield_init},
     meta::meta_init,
-    position::{get_position, positions_init, PositionOrId},
+    position::{get_position, positions_init, ActionType, PositionOrId},
     set_factory_addr,
     token::token_init,
 };
@@ -109,7 +109,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> R
         let pos = get_position(ctx.storage, id)?;
 
         let starts_at = pos.liquifunded_at;
-        state.position_liquifund_store(ctx, pos, starts_at, now, false)?;
+        state.position_liquifund_store(ctx, pos, starts_at, now, false, ActionType::User)?;
 
         Ok(())
     }

--- a/contracts/market/src/state/config.rs
+++ b/contracts/market/src/state/config.rs
@@ -50,6 +50,8 @@ pub(crate) fn update_config(
         crank_fee_charged,
         crank_fee_reward,
         minimum_deposit_usd: minimum_deposit,
+        unpend_limit,
+        liquifunding_delay_fuzz_seconds,
     }: ConfigUpdate,
 ) -> Result<()> {
     if let Some(x) = trading_fee_notional_size {
@@ -149,6 +151,12 @@ pub(crate) fn update_config(
     }
     if let Some(x) = minimum_deposit {
         config.minimum_deposit_usd = x;
+    }
+    if let Some(x) = unpend_limit {
+        config.unpend_limit = x;
+    }
+    if let Some(x) = liquifunding_delay_fuzz_seconds {
+        config.liquifunding_delay_fuzz_seconds = x;
     }
 
     config.validate()?;

--- a/contracts/market/src/state/crank.rs
+++ b/contracts/market/src/state/crank.rs
@@ -8,13 +8,13 @@ use msg::contracts::market::{
 
 use shared::prelude::*;
 
-use super::position::{get_position, NEXT_LIQUIFUNDING, NEXT_STALE, OPEN_POSITIONS};
+use super::position::{get_position, ActionType, NEXT_LIQUIFUNDING, NEXT_STALE, OPEN_POSITIONS};
 
 /// The last price point timestamp for which the cranking process was completed.
 ///
 /// If this is unavailable, we've never completed cranking, and we should find
 /// the very first price timestamp.
-const LAST_CRANK_COMPLETED: Item<Timestamp> = Item::new(namespace::LAST_CRANK_COMPLETED);
+pub(super) const LAST_CRANK_COMPLETED: Item<Timestamp> = Item::new(namespace::LAST_CRANK_COMPLETED);
 
 pub(crate) fn crank_init(store: &mut dyn Storage, env: &Env) -> Result<()> {
     LAST_CRANK_COMPLETED
@@ -184,7 +184,14 @@ impl State<'_> {
                 let pos = get_position(ctx.storage, position)?;
                 let starts_at = pos.liquifunded_at;
                 let ends_at = pos.next_liquifunding;
-                self.position_liquifund_store(ctx, pos, starts_at, ends_at, true)?;
+                self.position_liquifund_store(
+                    ctx,
+                    pos,
+                    starts_at,
+                    ends_at,
+                    true,
+                    ActionType::Crank,
+                )?;
             }
             CrankWorkInfo::UnpendLiquidationPrices { position } => {
                 self.unpend_liquidation_prices(ctx, position)?;

--- a/contracts/market/src/state/position.rs
+++ b/contracts/market/src/state/position.rs
@@ -57,6 +57,14 @@ pub(super) const PRICE_TRIGGER_ASC: Map<(PriceKey, PositionId), LiquidationReaso
 pub(super) const LIQUIDATION_PRICES_PENDING: Map<(Timestamp, PositionId), ()> =
     Map::new(namespace::LIQUIDATION_PRICES_PENDING);
 
+/// How many positions are sitting in the pending queue.
+///
+/// Note that during migration of data, this field may start off empty. The rest
+/// of the code needs to account for that possibility, and if trying to subtract
+/// from 0, should simply provide 0 as the value here.
+pub(super) const LIQUIDATION_PRICES_PENDING_COUNT: Item<u32> =
+    Item::new(namespace::LIQUIDATION_PRICES_PENDING_COUNT);
+
 /// Timestamp of the last time the liquidation prices were set.
 pub(super) const LIQUIDATION_PRICES_PENDING_REVERSE: Map<PositionId, Timestamp> =
     Map::new(namespace::LIQUIDATION_PRICES_PENDING_REVERSE);
@@ -572,6 +580,46 @@ impl State<'_> {
                 }
             }))
     }
+
+    /// Decrement the pending position count by one.
+    fn decrement_pending_count(&self, ctx: &mut StateContext) -> Result<()> {
+        let new = LIQUIDATION_PRICES_PENDING_COUNT
+            .may_load(ctx.storage)?
+            .unwrap_or_default()
+            .checked_sub(1)
+            .unwrap_or_default();
+        LIQUIDATION_PRICES_PENDING_COUNT.save(ctx.storage, &new)?;
+        Ok(())
+    }
+
+    /// Increment the pending count
+    ///
+    /// If this is a user driven action (like open or update), we block this
+    /// action if we've already hit our congestion limit. For automated actions
+    /// like cranked liquifundings, we always let the unpending occur.
+    fn increment_pending_count(
+        &self,
+        ctx: &mut StateContext,
+        action_type: ActionType,
+    ) -> Result<()> {
+        let old = LIQUIDATION_PRICES_PENDING_COUNT
+            .may_load(ctx.storage)?
+            .unwrap_or_default();
+
+        if action_type == ActionType::User && old >= self.config.unpend_limit {
+            return Err(MarketError::Congestion {
+                current_queue: old,
+                max_size: self.config.unpend_limit,
+            }
+            .into_anyhow());
+        }
+
+        // If we hit the numeric overflow, then (1) that's insane and (2) just keep the old value, we're allowed to undercount this.
+        if let Some(new) = old.checked_add(1) {
+            LIQUIDATION_PRICES_PENDING_COUNT.save(ctx.storage, &new)?;
+        }
+        Ok(())
+    }
 }
 
 pub(crate) fn positions_init(store: &mut dyn Storage) -> Result<()> {
@@ -630,6 +678,7 @@ impl State<'_> {
         price_point: &PricePoint,
         is_update: bool,
         recalc_liquidation_margin: bool,
+        action_type: ActionType,
     ) -> Result<()> {
         if is_update {
             self.position_remove(ctx, pos.id)?;
@@ -677,7 +726,7 @@ impl State<'_> {
         OPEN_POSITIONS.save(ctx.storage, pos.id, pos)?;
         NEXT_LIQUIFUNDING.save(ctx.storage, (pos.next_liquifunding, pos.id), &())?;
         NEXT_STALE.save(ctx.storage, (pos.stale_at, pos.id), &())?;
-        self.store_liquidation_prices(ctx, pos)?;
+        self.store_liquidation_prices(ctx, pos, action_type)?;
 
         self.increase_total_funding_margin(ctx, pos.liquidation_margin.funding)?;
 
@@ -689,8 +738,13 @@ impl State<'_> {
         if let Some(updated_at) =
             LIQUIDATION_PRICES_PENDING_REVERSE.may_load(ctx.storage, pos.id)?
         {
-            LIQUIDATION_PRICES_PENDING_REVERSE.remove(ctx.storage, pos.id);
-            LIQUIDATION_PRICES_PENDING.remove(ctx.storage, (updated_at, pos.id));
+            if LIQUIDATION_PRICES_PENDING.has(ctx.storage, (updated_at, pos.id)) {
+                self.decrement_pending_count(ctx)?;
+                LIQUIDATION_PRICES_PENDING_REVERSE.remove(ctx.storage, pos.id);
+                LIQUIDATION_PRICES_PENDING.remove(ctx.storage, (updated_at, pos.id));
+            } else {
+                debug_assert!(!LIQUIDATION_PRICES_PENDING_REVERSE.has(ctx.storage, pos.id))
+            }
         }
 
         match pos.direction() {
@@ -746,13 +800,19 @@ impl State<'_> {
     /// [LIQUIDATION_PRICES_PENDING] queue so that historical price updates
     /// can't trigger liquidation/take profit.  Actually adding them will then
     /// occur in the crank.
-    fn store_liquidation_prices(&self, ctx: &mut StateContext, pos: &Position) -> Result<()> {
+    fn store_liquidation_prices(
+        &self,
+        ctx: &mut StateContext,
+        pos: &Position,
+        action_type: ActionType,
+    ) -> Result<()> {
         if self.is_crank_up_to_date(ctx.storage)? {
             self.store_liquidation_prices_inner(ctx, pos)?;
         } else {
             let now = self.now();
             LIQUIDATION_PRICES_PENDING_REVERSE.save(ctx.storage, pos.id, &now)?;
             LIQUIDATION_PRICES_PENDING.save(ctx.storage, (now, pos.id), &())?;
+            self.increment_pending_count(ctx, action_type)?;
         }
 
         Ok(())
@@ -767,6 +827,7 @@ impl State<'_> {
         let updated_at = LIQUIDATION_PRICES_PENDING_REVERSE.load(ctx.storage, posid)?;
         LIQUIDATION_PRICES_PENDING_REVERSE.remove(ctx.storage, posid);
         LIQUIDATION_PRICES_PENDING.remove(ctx.storage, (updated_at, posid));
+        self.decrement_pending_count(ctx)?;
 
         let pos = OPEN_POSITIONS.load(ctx.storage, posid)?;
         self.store_liquidation_prices_inner(ctx, &pos)
@@ -872,4 +933,14 @@ impl AdjustOpenInterestResult {
         }
         Ok(())
     }
+}
+
+/// What kind of an action triggered this transaction?
+#[derive(PartialEq, Eq)]
+pub(crate) enum ActionType {
+    /// An automated crank action
+    Crank,
+    /// A user driven action like opening a position, setting trigger orders,
+    /// etc
+    User,
 }

--- a/contracts/market/src/state/position/liquifund.rs
+++ b/contracts/market/src/state/position/liquifund.rs
@@ -1,7 +1,14 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use crate::prelude::*;
 use msg::contracts::market::position::{
     ClosePositionInstructions, LiquidationReason, MaybeClosedPosition, PositionCloseReason,
 };
+
+use super::ActionType;
 
 impl State<'_> {
     /// Same as [State::position_liquifund], but update the stored data with the resulting [MaybeClosedPosition].
@@ -12,21 +19,23 @@ impl State<'_> {
         starts_at: Timestamp,
         ends_at: Timestamp,
         charge_crank_fee: bool,
+        action_type: ActionType,
     ) -> Result<()> {
         let mcp = self.position_liquifund(ctx, pos, starts_at, ends_at, charge_crank_fee)?;
-        self.process_maybe_closed_position(ctx, mcp, ends_at)
+        self.process_maybe_closed_position(ctx, mcp, ends_at, action_type)
     }
 
-    pub(crate) fn process_maybe_closed_position(
+    fn process_maybe_closed_position(
         &self,
         ctx: &mut StateContext,
         mcp: MaybeClosedPosition,
         ends_at: Timestamp,
+        action_type: ActionType,
     ) -> Result<()> {
         match mcp {
             MaybeClosedPosition::Open(mut position) => {
                 let price_point = self.spot_price(ctx.storage, Some(ends_at))?;
-                self.position_save(ctx, &mut position, &price_point, true, false)?;
+                self.position_save(ctx, &mut position, &price_point, true, false, action_type)?;
                 Ok(())
             }
             MaybeClosedPosition::Close(close_position_instructions) => {
@@ -130,12 +139,50 @@ impl State<'_> {
         };
 
         // Position does not need to be closed
-        pos.liquifunded_at = ends_at;
-        pos.next_liquifunding = ends_at.plus_seconds(config.liquifunding_delay_seconds.into());
-        pos.stale_at = pos
-            .next_liquifunding
-            .plus_seconds(config.staleness_seconds.into());
+        self.set_next_liquifunding_and_stale_at(&mut pos, ends_at);
         pos.liquidation_margin = liquidation_margin;
         Ok(MaybeClosedPosition::Open(pos))
+    }
+
+    /// Updates the liquifunded_at, next_liquifunding, and stale_at fields of the position.
+    ///
+    /// Includes logic for randomization of the next_liquifunding field
+    pub(crate) fn set_next_liquifunding_and_stale_at(
+        &self,
+        pos: &mut Position,
+        liquifunded_at: Timestamp,
+    ) {
+        // First set up the values correctly
+        pos.liquifunded_at = liquifunded_at;
+        pos.next_liquifunding =
+            liquifunded_at.plus_seconds(self.config.liquifunding_delay_seconds.into());
+        pos.stale_at = pos
+            .next_liquifunding
+            .plus_seconds(self.config.staleness_seconds.into());
+
+        if self.config.liquifunding_delay_fuzz_seconds != 0 {
+            // Next we're going to add a bit of randomization to schedule the
+            // next_liquifunding earlier than it should be. This is part of the
+            // crank smoothing mechanism. We don't need true randomness for this,
+            // just something random enough to spread load around.
+            let mut hash = DefaultHasher::new();
+            self.now().hash(&mut hash);
+            pos.owner.hash(&mut hash);
+            pos.id.hash(&mut hash);
+            let semi_random = hash.finish();
+
+            // If anything goes wrong, we just ignore it. This is an optimization that is
+            // allowed to fail.
+            let res = (|| {
+                let how_early_seconds =
+                    semi_random.checked_rem(self.config.liquifunding_delay_fuzz_seconds.into())?;
+                let actual_delay = u64::from(self.config.liquifunding_delay_seconds)
+                    .checked_sub(how_early_seconds)?;
+                pos.next_liquifunding = liquifunded_at.plus_seconds(actual_delay);
+
+                Some(())
+            })();
+            debug_assert_eq!(res, Some(()));
+        }
     }
 }

--- a/contracts/market/src/state/position/open.rs
+++ b/contracts/market/src/state/position/open.rs
@@ -121,6 +121,8 @@ impl State<'_> {
                 .map(|x| x.into_notional_price(market_type)),
         };
 
+        self.set_next_liquifunding_and_stale_at(&mut pos, liquifunded_at);
+
         let trade_volume_usd = trade_volume_usd(&pos, price_point, market_type)?;
 
         // Validate leverage before removing trading fees from active collateral
@@ -212,7 +214,14 @@ impl State<'_> {
         self.liquidity_lock(ctx, pos.counter_collateral)?;
 
         // Save the position, setting liquidation margin and prices
-        self.position_save(ctx, &mut pos, &price_point, false, true)?;
+        self.position_save(
+            ctx,
+            &mut pos,
+            &price_point,
+            false,
+            true,
+            super::ActionType::User,
+        )?;
 
         // mint the nft
         self.nft_mint(ctx, pos.owner.clone(), pos.id.to_string())?;

--- a/contracts/market/src/state/position/update.rs
+++ b/contracts/market/src/state/position/update.rs
@@ -10,6 +10,8 @@ use msg::contracts::market::position::events::{
 use msg::contracts::market::position::MaybeClosedPosition;
 use msg::contracts::market::position::{events::PositionUpdateEvent, Position, PositionId};
 
+use super::ActionType;
+
 impl State<'_> {
     pub(crate) fn update_leverage_new_notional_size(
         &self,
@@ -254,7 +256,7 @@ impl State<'_> {
 
         // Storage and external
         self.position_update_emit_event(ctx, &original_pos, pos.clone(), spot_price)?;
-        self.position_save(ctx, &mut pos, &spot_price, true, true)?;
+        self.position_save(ctx, &mut pos, &spot_price, true, true, ActionType::User)?;
 
         // Validate
         self.position_validate_leverage_data(market_type, &pos, &spot_price, Some(&original_pos))?;
@@ -359,7 +361,7 @@ impl State<'_> {
             DeltaNeutralityFeeReason::PositionUpdate,
         )?
         .store(self, ctx)?;
-        self.position_save(ctx, &mut pos, &spot_price, true, true)?;
+        self.position_save(ctx, &mut pos, &spot_price, true, true, ActionType::User)?;
         self.adjust_net_open_interest(ctx, notional_size_diff, pos.direction(), true)?;
         self.add_delta_neutrality_ratio_event(
             ctx,
@@ -469,7 +471,7 @@ impl State<'_> {
             DeltaNeutralityFeeReason::PositionUpdate,
         )?
         .store(self, ctx)?;
-        self.position_save(ctx, &mut pos, &spot_price, true, true)?;
+        self.position_save(ctx, &mut pos, &spot_price, true, true, ActionType::User)?;
         self.adjust_net_open_interest(ctx, notional_size_diff, pos.direction(), true)?;
         self.add_delta_neutrality_ratio_event(
             ctx,
@@ -538,7 +540,7 @@ impl State<'_> {
         pos.trading_fee
             .checked_add_assign(trading_fee_delta, &spot_price)?;
 
-        self.position_save(ctx, &mut pos, &spot_price, true, true)?;
+        self.position_save(ctx, &mut pos, &spot_price, true, true, ActionType::User)?;
 
         let notional_size_diff = pos.notional_size - original_pos.notional_size;
         debug_assert!(notional_size_diff.is_zero());
@@ -583,7 +585,7 @@ impl State<'_> {
         match self.position_liquifund(ctx, pos, last_liquifund, self.now(), false)? {
             MaybeClosedPosition::Open(mut pos) => {
                 self.position_validate_trigger_orders(&pos, market_type, price)?;
-                self.position_save(ctx, &mut pos, &price, true, false)?;
+                self.position_save(ctx, &mut pos, &price, true, false, ActionType::User)?;
             }
             MaybeClosedPosition::Close(_) => anyhow::bail!("Cannot update trigger orders since the position will be closed on next liquifunding"),
         }

--- a/packages/msg/src/contracts/market/entry.rs
+++ b/packages/msg/src/contracts/market/entry.rs
@@ -999,6 +999,10 @@ pub struct StatusResp {
     pub liquidity: super::liquidity::LiquidityStats,
     /// Next bit of crank work available, if any
     pub next_crank: Option<CrankWorkInfo>,
+    /// Timestamp of the last completed crank
+    pub last_crank_completed: Option<Timestamp>,
+    /// Size of the unpend queue
+    pub unpend_queue_size: u32,
     /// Overall borrow fee rate (annualized), combining LP and xLP
     pub borrow_fee: Decimal256,
     /// LP component of [Self::borrow_fee]
@@ -1032,6 +1036,8 @@ pub struct StatusResp {
     pub stale_liquifunding: Option<Timestamp>,
     /// Is the last price update too old? If so, contains [Option::Some], and the timestamp when the price became too old.
     pub stale_price: Option<Timestamp>,
+    /// Are we in the congested state where new positions cannot be opened?
+    pub congested: bool,
 
     /// Fees held by the market contract
     pub fees: Fees,

--- a/packages/multi_test/tests/multi_test/funding.rs
+++ b/packages/multi_test/tests/multi_test/funding.rs
@@ -209,6 +209,8 @@ fn funding_payment_typical() {
     market
         .exec_set_config(ConfigUpdate {
             liquifunding_delay_seconds: Some(40 * 60),
+            // We need precise liquifunding periods for this test so remove randomization
+            liquifunding_delay_fuzz_seconds: Some(0),
             staleness_seconds: Some(20 * 60),
             ..Default::default()
         })
@@ -349,6 +351,8 @@ fn funding_borrow_fee() {
     market
         .exec_set_config(ConfigUpdate {
             liquifunding_delay_seconds: Some(60 * 60),
+            // We need precise liquifunding periods for this test so remove randomization
+            liquifunding_delay_fuzz_seconds: Some(0),
             staleness_seconds: Some(20 * 60),
             ..Default::default()
         })

--- a/packages/multi_test/tests/multi_test/liquidity.rs
+++ b/packages/multi_test/tests/multi_test/liquidity.rs
@@ -189,6 +189,8 @@ fn liquidity_claim_yield_from_borrow_fee() {
             borrow_fee_rate_min_annualized: Some("0.01".parse().unwrap()),
             borrow_fee_rate_max_annualized: Some("0.01".parse().unwrap()),
             delta_neutrality_fee_tax: Some(Decimal256::zero()),
+            // We need precise liquifunding periods for this test so remove randomization
+            liquifunding_delay_fuzz_seconds: Some(0),
             ..Default::default()
         })
         .unwrap();

--- a/packages/multi_test/tests/multi_test/position/congestion.rs
+++ b/packages/multi_test/tests/multi_test/position/congestion.rs
@@ -1,0 +1,93 @@
+use std::collections::HashSet;
+
+use levana_perpswap_multi_test::{market_wrapper::PerpsMarket, PerpsApp};
+use msg::prelude::*;
+
+#[test]
+fn test_congestion_block() {
+    let market = PerpsMarket::new(PerpsApp::new_cell().unwrap()).unwrap();
+    let trader = market.clone_trader(0).unwrap();
+
+    // Do a price update without cranking to force unpending the position
+    market.exec_set_price("1.02".parse().unwrap()).unwrap();
+
+    // We can open up a bunch of positions without a crank...
+    for _ in 0..market.query_status().unwrap().config.unpend_limit {
+        market
+            .exec_open_position(
+                &trader,
+                "5",
+                "5",
+                DirectionToBase::Long,
+                "2",
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+    }
+
+    // Opening the next position should fail
+    let err = market
+        .exec_open_position(
+            &trader,
+            "5",
+            "5",
+            DirectionToBase::Long,
+            "2",
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+    let err: PerpError<MarketError> = err.downcast().unwrap();
+    assert_eq!(err.id, ErrorId::Congestion);
+
+    // Now we crank...
+    market.exec_crank_till_finished(&trader).unwrap();
+
+    // And now opening should be fine
+    market
+        .exec_open_position(
+            &trader,
+            "5",
+            "5",
+            DirectionToBase::Long,
+            "2",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+}
+
+#[test]
+fn randomization() {
+    let market = PerpsMarket::new(PerpsApp::new_cell().unwrap()).unwrap();
+    let trader = market.clone_trader(0).unwrap();
+    let mut timestamps = HashSet::new();
+
+    // We can open up a bunch of positions without a crank...
+    for _ in 0..market.query_status().unwrap().config.unpend_limit {
+        let (pos_id, _) = market
+            .exec_open_position(
+                &trader,
+                "5",
+                "5",
+                DirectionToBase::Long,
+                "2",
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let pos = market.query_position(pos_id).unwrap();
+
+        let is_new = timestamps.insert(pos.next_liquifunding);
+        assert!(
+            is_new,
+            "Duplicated next_liquifunding: {}",
+            pos.next_liquifunding
+        );
+    }
+}

--- a/packages/multi_test/tests/multi_test/position/mod.rs
+++ b/packages/multi_test/tests/multi_test/position/mod.rs
@@ -1,4 +1,5 @@
 pub mod close;
+pub mod congestion;
 pub mod data;
 pub mod infinite_gains;
 pub mod liquidate;

--- a/packages/multi_test/tests/multi_test/position/pnl.rs
+++ b/packages/multi_test/tests/multi_test/position/pnl.rs
@@ -253,6 +253,8 @@ fn position_pnl_long_and_short_precise() {
     market
         .exec_set_config(ConfigUpdate {
             liquifunding_delay_seconds: Some(60 * 60),
+            // We need precise liquifunding periods for this test so remove randomization
+            liquifunding_delay_fuzz_seconds: Some(0),
             delta_neutrality_fee_tax: Some(Decimal256::zero()),
             ..Default::default()
         })

--- a/packages/shared/src/error.rs
+++ b/packages/shared/src/error.rs
@@ -69,6 +69,7 @@ pub enum ErrorId {
     TraderLeverageOutOfRange,
     CounterLeverageOutOfRange,
     MinimumDeposit,
+    Congestion,
 }
 
 /// Source within the protocol for the error

--- a/packages/shared/src/error/market.rs
+++ b/packages/shared/src/error/market.rs
@@ -63,6 +63,8 @@ pub enum MarketError {
         deposit_usd: Usd,
         minimum_usd: Usd,
     },
+    #[error("Cannot open or update positions currently, the position queue size is {current_queue}, while the allowed size is {max_size}. Please try again later")]
+    Congestion { current_queue: u32, max_size: u32 },
 }
 
 impl MarketError {
@@ -112,6 +114,7 @@ impl MarketError {
             MarketError::TraderLeverageOutOfRange { .. } => ErrorId::TraderLeverageOutOfRange,
             MarketError::CounterLeverageOutOfRange { .. } => ErrorId::CounterLeverageOutOfRange,
             MarketError::MinimumDeposit { .. } => ErrorId::MinimumDeposit,
+            MarketError::Congestion { .. } => ErrorId::Congestion,
         }
     }
 }

--- a/packages/shared/src/namespace.rs
+++ b/packages/shared/src/namespace.rs
@@ -125,3 +125,4 @@ pub const PYTH_ADDR: &str = "dr";
 pub const PYTH_MARKET_PRICE_FEEDS: &str = "ds";
 pub const PYTH_UPDATE_AGE_TOLERANCE: &str = "dt";
 pub const PYTH_PREV_MARKET_PRICE: &str = "du";
+pub const LIQUIDATION_PRICES_PENDING_COUNT: &str = "dv";

--- a/packages/shared/src/time.rs
+++ b/packages/shared/src/time.rs
@@ -19,7 +19,7 @@ use std::ops::{Add, Div, Mul, Sub};
 /// directly (instead of a [Timestamp] or [cosmwasm_std::Uint64]) to make it
 /// easier to derive some impls. The result is that we need to explicitly
 /// implement [Serialize] and [Deserialize] to keep the stringy representation.
-#[derive(Debug, Clone, Default, Copy, Eq, PartialEq, Ord, PartialOrd, JsonSchema)]
+#[derive(Debug, Clone, Default, Copy, Eq, PartialEq, Ord, PartialOrd, JsonSchema, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Timestamp(#[schemars(with = "String")] u64);
 


### PR DESCRIPTION
* Limit the size of the unpend queue
* Add randomization to next_liquifunding
* Provide more data in Status about staleness, cranking, and unpend queue