### PR TITLE
Remove redundant ensure_missing

### DIFF
--- a/contracts/market/src/state/sanity.rs
+++ b/contracts/market/src/state/sanity.rs
@@ -225,8 +225,6 @@ fn liquidation_prices(store: &dyn Storage, _env: &Env) -> Result<()> {
             Some(_) => {
                 ensure_missing(store, PRICE_TRIGGER_DESC, posid)?;
                 ensure_missing(store, PRICE_TRIGGER_ASC, posid)?;
-                ensure_missing(store, PRICE_TRIGGER_ASC, posid)?;
-                ensure_missing(store, PRICE_TRIGGER_DESC, posid)?;
             }
         }
     }


### PR DESCRIPTION
This was probably introduced when we combined the long-maxgains and short-liquidation into a single Map.