### PR TITLE
perp-1397 | dnf_on_close_collateral

### DIFF
--- a/contracts/market/src/state/position.rs
+++ b/contracts/market/src/state/position.rs
@@ -429,7 +429,7 @@ impl State<'_> {
             .split()
             .0;
 
-        if calc_pending_fees {
+        let dnf_on_close_collateral = if calc_pending_fees {
             // Calculate pending fees
             let (borrow_fees, _) =
                 self.calc_capped_borrow_fee_payment(store, &pos, pos.liquifunded_at, self.now())?;
@@ -484,7 +484,10 @@ impl State<'_> {
                     "0.00001".parse().unwrap()
                 }
             };
-        }
+            Some(delta_neutrality_fee)
+        } else {
+            None
+        };
 
         let start_price = self.spot_price(store, Some(pos.liquifunded_at))?;
         pos.into_query_response_extrapolate_exposure(
@@ -495,6 +498,7 @@ impl State<'_> {
             config,
             market_type,
             original_direction_to_base,
+            dnf_on_close_collateral,
         )
     }
 

--- a/packages/multi_test/src/market_wrapper.rs
+++ b/packages/multi_test/src/market_wrapper.rs
@@ -398,7 +398,9 @@ impl PerpsMarket {
         })?;
         anyhow::ensure!(pending_close.is_empty());
         anyhow::ensure!(closed.is_empty());
-        positions.pop().ok_or_else(|| anyhow!("no positions"))
+        let pos = positions.pop().ok_or_else(|| anyhow!("no positions"))?;
+        anyhow::ensure!(pos.dnf_on_close_collateral == None);
+        Ok(pos)
     }
 
     pub fn query_position_with_pending_fees(
@@ -415,7 +417,9 @@ impl PerpsMarket {
         })?;
         anyhow::ensure!(pending_close.is_empty());
         anyhow::ensure!(closed.is_empty());
-        positions.pop().ok_or_else(|| anyhow!("no positions"))
+        let pos = positions.pop().ok_or_else(|| anyhow!("no positions"))?;
+        anyhow::ensure!(pos.dnf_on_close_collateral != None);
+        Ok(pos)
     }
 
     pub fn query_position_pending_close(

--- a/packages/multi_test/tests/multi_test/position/data.rs
+++ b/packages/multi_test/tests/multi_test/position/data.rs
@@ -230,6 +230,7 @@ fn position_data_open_flip_short() {
             },
             entry_price,
             MarketType::CollateralIsBase,
+            None,
         )
         .unwrap();
 
@@ -295,6 +296,7 @@ fn position_data_open_flip_long() {
             },
             entry_price,
             MarketType::CollateralIsBase,
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
One design point worth bringing up here. I didn't bother including a USD version of the PnL, since there's no cost-basis calculations needed for it. I figured it was easy enough to do the conversion on the frontend.