### PR TITLE
spot price history query fix

### DIFF
--- a/contracts/market/src/state/market.rs
+++ b/contracts/market/src/state/market.rs
@@ -104,12 +104,19 @@ impl State<'_> {
         limit: Option<usize>,
         order: Option<Order>,
     ) -> Result<Vec<PricePoint>> {
+        let order = order.unwrap_or(Order::Descending);
         let iter = PRICES
             .range(
                 store,
-                start_after.map(Bound::exclusive),
-                None,
-                order.unwrap_or(Order::Descending),
+                match order {
+                    Order::Ascending => start_after.map(Bound::exclusive),
+                    Order::Descending => None,
+                },
+                match order {
+                    Order::Ascending => None,
+                    Order::Descending => start_after.map(Bound::exclusive),
+                },
+                order,
             )
             .map(|res| {
                 let (timestamp, price_storage) = res?;

--- a/packages/multi_test/src/market_wrapper.rs
+++ b/packages/multi_test/src/market_wrapper.rs
@@ -631,12 +631,16 @@ impl PerpsMarket {
         })
     }
 
-    pub fn query_spot_price_history(&self) -> Result<Vec<PricePoint>> {
-        // NOTE we're not doing any pagination, it will load everything
+    pub fn query_spot_price_history(
+        &self,
+        start_after: Option<Timestamp>,
+        limit: Option<u32>,
+        order: Option<OrderInMessage>,
+    ) -> Result<Vec<PricePoint>> {
         let resp: SpotPriceHistoryResp = self.query(&MarketQueryMsg::SpotPriceHistory {
-            start_after: None,
-            limit: None,
-            order: Some(OrderInMessage::Ascending),
+            start_after,
+            limit,
+            order,
         })?;
 
         Ok(resp.price_points)

--- a/packages/multi_test/tests/multi_test/history.rs
+++ b/packages/multi_test/tests/multi_test/history.rs
@@ -378,17 +378,74 @@ fn trade_history_nft_transfer_perp_963() {
 fn price_history_works() {
     let market = PerpsMarket::new(PerpsApp::new_cell().unwrap()).unwrap();
 
-    let start_len = market.query_spot_price_history().unwrap().len();
+    let start_len = market
+        .query_spot_price_history(None, None, None)
+        .unwrap()
+        .len();
 
-    market.exec_set_price("2.0".parse().unwrap()).unwrap();
-    market.exec_set_price("3.0".parse().unwrap()).unwrap();
-    market.exec_set_price("4.0".parse().unwrap()).unwrap();
+    for i in 2..=10 {
+        market
+            .exec_set_price(format!("{}", i).parse().unwrap())
+            .unwrap();
+    }
 
-    let mut prices = market.query_spot_price_history().unwrap();
+    let prices = market
+        .query_spot_price_history(None, None, Some(OrderInMessage::Ascending))
+        .unwrap();
 
-    assert_eq!(prices.len() - start_len, 3);
+    assert_eq!(prices.len() - start_len, 9);
 
-    assert_eq!(prices.pop().unwrap().price_base, "4.0".parse().unwrap());
-    assert_eq!(prices.pop().unwrap().price_base, "3.0".parse().unwrap());
-    assert_eq!(prices.pop().unwrap().price_base, "2.0".parse().unwrap());
+    for (i, price) in prices.iter().enumerate() {
+        assert_eq!(price.price_base, (i + 1).to_string().parse().unwrap());
+    }
+
+    let prices = market
+        .query_spot_price_history(None, None, Some(OrderInMessage::Descending))
+        .unwrap();
+
+    assert_eq!(prices.len() - start_len, 9);
+
+    for i in 1..=prices.len() {
+        assert_eq!(prices[10 - i].price_base, i.to_string().parse().unwrap());
+    }
+
+    let prices_desc_page_1 = market
+        .query_spot_price_history(None, Some(3), Some(OrderInMessage::Descending))
+        .unwrap();
+    let prices_desc_page_2 = market
+        .query_spot_price_history(
+            Some(prices_desc_page_1.last().unwrap().timestamp),
+            None,
+            Some(OrderInMessage::Descending),
+        )
+        .unwrap();
+    let prices_desc = prices_desc_page_1
+        .iter()
+        .chain(prices_desc_page_2.iter())
+        .map(|p| p.price_base.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        vec!["10", "9", "8", "7", "6", "5", "4", "3", "2", "1"],
+        prices_desc
+    );
+
+    let prices_asc_page_1 = market
+        .query_spot_price_history(None, Some(3), Some(OrderInMessage::Ascending))
+        .unwrap();
+    let prices_asc_page_2 = market
+        .query_spot_price_history(
+            Some(prices_asc_page_1.last().unwrap().timestamp),
+            None,
+            Some(OrderInMessage::Ascending),
+        )
+        .unwrap();
+    let prices_asc = prices_asc_page_1
+        .iter()
+        .chain(prices_asc_page_2.iter())
+        .map(|p| p.price_base.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        vec!["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+        prices_asc
+    );
 }


### PR DESCRIPTION
this is a pretty common pattern... I assume we have test coverage to catch it elsewhere, but it would be great if we can abstract it to avoid accidental bugs like this from creeping in (the abstraction idea is outside the scope of this PR, which is just a distinct bugfix and more comprehensive tests)