### PR TITLE
Put retry config within TaksConfig

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/watcher.rs
+++ b/packages/perps-exes/src/bin/perps-bots/watcher.rs
@@ -274,7 +274,8 @@ impl AppBuilder {
                     Err(err) => {
                         log::warn!("{label}: Error: {err:?}");
                         retries += 1;
-                        if retries >= app.config.watcher.retries {
+                        let max_retries = config.retries.unwrap_or(app.config.watcher.retries);
+                        if retries >= max_retries {
                             retries = 0;
                             *task_status.write() = TaskStatus {
                                 last_result: TaskResult {
@@ -301,7 +302,10 @@ impl AppBuilder {
                             }
 
                             tokio::time::sleep(tokio::time::Duration::from_secs(
-                                app.config.watcher.delay_between_retries.into(),
+                                config
+                                    .delay_between_retries
+                                    .unwrap_or(app.config.watcher.delay_between_retries)
+                                    .into(),
                             ))
                             .await;
                         }

--- a/packages/perps-exes/src/config.rs
+++ b/packages/perps-exes/src/config.rs
@@ -260,19 +260,25 @@ pub struct WatcherConfig {
 impl Default for WatcherConfig {
     fn default() -> Self {
         Self {
-            retries: 6,
-            delay_between_retries: 20,
+            retries: defaults::retries(),
+            delay_between_retries: defaults::delay_between_retries(),
             balance: TaskConfig {
                 delay: Delay::Constant(20),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             gas_check: TaskConfig {
                 delay: Delay::Constant(60),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             liquidity: TaskConfig {
                 delay: Delay::Constant(120),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             trader: TaskConfig {
                 delay: Delay::Random {
@@ -280,38 +286,59 @@ impl Default for WatcherConfig {
                     high: 1200,
                 },
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             utilization: TaskConfig {
                 delay: Delay::Constant(120),
                 out_of_date: 120,
+                retries: None,
+                delay_between_retries: None,
             },
             track_balance: TaskConfig {
                 delay: Delay::Constant(60),
                 out_of_date: 60,
+                retries: None,
+                delay_between_retries: None,
             },
             crank: TaskConfig {
                 delay: Delay::Constant(30),
                 out_of_date: 60,
+                retries: None,
+                delay_between_retries: None,
             },
             get_factory: TaskConfig {
                 delay: Delay::Constant(60),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             price: TaskConfig {
                 delay: Delay::Interval(1),
                 out_of_date: 30,
+                // Intentionally using different defaults to make sure price
+                // updates come through quickly. We increase our retries to
+                // compensate for the shorter delay.
+                retries: Some(20),
+                delay_between_retries: Some(1),
             },
             stale: TaskConfig {
                 delay: Delay::Constant(30),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             stats: TaskConfig {
                 delay: Delay::Constant(30),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
             ultra_crank: TaskConfig {
                 delay: Delay::Constant(120),
                 out_of_date: 180,
+                retries: None,
+                delay_between_retries: None,
             },
         }
     }
@@ -326,6 +353,12 @@ pub struct TaskConfig {
     ///
     /// This does not include the delay time
     pub out_of_date: u32,
+    /// How many times to retry before giving up, overriding the general watcher
+    /// config
+    pub retries: Option<usize>,
+    /// How many seconds to delay between retries, overriding the general
+    /// watcher config
+    pub delay_between_retries: Option<u32>,
 }
 
 #[derive(serde::Deserialize, Clone, Copy, Debug)]

--- a/packages/perps-exes/src/config/defaults.rs
+++ b/packages/perps-exes/src/config/defaults.rs
@@ -13,7 +13,7 @@ pub(super) fn min_gas_in_gas_wallet() -> u128 {
 }
 
 pub(super) fn retries() -> usize {
-    4
+    6
 }
 
 pub(super) fn delay_between_retries() -> u32 {


### PR DESCRIPTION
This lets us have different retry rules for each task, which is important for price. We don't want to wait 20 seconds to retry a price update.