### PR TITLE
Disable ultra crank on seibeta

### DIFF
--- a/packages/perps-exes/assets/config-testnet.yaml
+++ b/packages/perps-exes/assets/config-testnet.yaml
@@ -106,7 +106,6 @@ overrides:
     wallet-manager-address: osmo12vhejqqdgnszlcs7nqdvlx3p5eqyudfslevx3k
     price-address: osmo1dfagdh540vrqqnuet5rqvdg3uldhhgdxpttmzl
     price: true
-    ultra-crank: 20
     crank: true
     liquidity: true
     utilization: true


### PR DESCRIPTION
Should no longer be necessary. Removing will slim down the amount of queries we hit the contracts with, plus make our status page a little easier to read. Also, it's a good test to ensure we weren't relying on the ultra crank to overcome network issues.