### PR TITLE
Include more info on what was cranked

### DIFF
--- a/contracts/market/src/state/crank.rs
+++ b/contracts/market/src/state/crank.rs
@@ -132,23 +132,22 @@ impl State<'_> {
         }
         .into();
 
-        let mut real_cranks = 0;
+        let mut actual = vec![];
         for _ in 0..n_execs {
             match self.crank_work(ctx.storage)? {
                 None => break,
                 Some(work_info) => {
+                    actual.push(work_info.clone());
                     self.crank_exec(ctx, work_info)?;
-                    real_cranks += 1;
                 }
             };
         }
 
+        self.allocate_crank_fees(ctx, rewards, actual.len().try_into()?)?;
         ctx.response_mut().add_event(CrankExecBatchEvent {
             requested: n_execs,
-            actual: real_cranks.into(),
+            actual,
         });
-
-        self.allocate_crank_fees(ctx, rewards, real_cranks)?;
 
         Ok(())
     }


### PR DESCRIPTION
This is based on needing to do some debugging in production. I'm seeing price updates come through with maximum cranks (7) very often while the crank queue seems empty. I'd like some event data to make it easier to understand what we're doing in the crank.