### PR TITLE
Less frequent price updates

### DIFF
--- a/packages/perps-exes/assets/config-testnet.yaml
+++ b/packages/perps-exes/assets/config-testnet.yaml
@@ -35,8 +35,6 @@ deployments:
     traders: 10
     default-market-ids:
       - ATOM_USD
-    # TODO Remove this once the frontend pushes its own price updates
-    max-price-age-secs: 1
   dev:
     wallet-manager-address: osmo1lkc7lnq204m4yeydcdg94stkm50jjyglh7ucel
     price-address: osmo1q47uh5e2v8gfr3efy03xs9m0qrz3d2g2fpdc7l
@@ -123,8 +121,6 @@ overrides:
     watcher:
       # Nodes seem to crash often, let's see if this helps
       retries: 10
-    # TODO Remove this once the frontend pushes its own price updates
-    max-price-age-secs: 1
   seitrade:
     wallet-manager-address: osmo19a93ag7hf49zqemds0x8nutldv7288drj6fw74
     price-address: osmo1uvllz6r8aye35rm38jdcjwe7r73wgcxvtsu4c6
@@ -145,5 +141,16 @@ overrides:
     watcher:
       # Nodes seem to crash often, let's see if this helps
       retries: 10
-    # TODO Remove this once the frontend pushes its own price updates
+  dragonbeta:
+    wallet-manager-address: osmo12vhejqqdgnszlcs7nqdvlx3p5eqyudfslevx3k
+    price-address: osmo1dfagdh540vrqqnuet5rqvdg3uldhhgdxpttmzl
+    price: true
+    crank: true
+    liquidity: true
+    utilization: true
+    balance: true
+    traders: 10
+    default-market-ids:
+      - ATOM_USD
+    # Can be removed once Dragonfire supports the Pyth oracle
     max-price-age-secs: 1


### PR DESCRIPTION
Now that the frontend is pushing price changes, we no longer need to force a price update every second.

Dragonfire, however, doesn't use Pyth yet, so we need to continue the frequent updates.