### PR TITLE
ClosedPosition includes deposit_collateral_usd

### DIFF
--- a/contracts/market/src/state/position/close.rs
+++ b/contracts/market/src/state/position/close.rs
@@ -144,6 +144,7 @@ impl State<'_> {
             crank_fee_collateral: pos.crank_fee.collateral(),
             crank_fee_usd: pos.crank_fee.usd(),
             deposit_collateral: pos.deposit_collateral.collateral(),
+            deposit_collateral_usd: pos.deposit_collateral.usd(),
             pnl_collateral: active_collateral
                 .into_signed()
                 .checked_sub(pos.deposit_collateral.collateral())?,

--- a/packages/msg/src/contracts/market/position.rs
+++ b/packages/msg/src/contracts/market/position.rs
@@ -611,6 +611,7 @@ impl Position {
                         crank_fee_collateral: pos.crank_fee.collateral(),
                         crank_fee_usd: pos.crank_fee.usd(),
                         deposit_collateral: pos.deposit_collateral.collateral(),
+                        deposit_collateral_usd: pos.deposit_collateral.usd(),
                         pnl_collateral: active_collateral
                             .into_signed()
                             .checked_sub(pos.deposit_collateral.collateral())?,
@@ -1061,6 +1062,7 @@ pub mod events {
                         delta_neutrality_fee_collateral,
                         delta_neutrality_fee_usd,
                         deposit_collateral,
+                        deposit_collateral_usd,
                         active_collateral,
                         pnl_collateral,
                         pnl_usd,
@@ -1097,6 +1099,10 @@ pub mod events {
                 .add_attribute(
                     event_key::DEPOSIT_COLLATERAL,
                     deposit_collateral.to_string(),
+                )
+                .add_attribute(
+                    event_key::DEPOSIT_COLLATERAL_USD,
+                    deposit_collateral_usd.to_string(),
                 )
                 .add_attribute(event_key::PNL, pnl_collateral.to_string())
                 .add_attribute(event_key::PNL_USD, pnl_usd.to_string())
@@ -1165,6 +1171,10 @@ pub mod events {
                     .number_attr(event_key::DELTA_NEUTRALITY_FEE)?,
                 delta_neutrality_fee_usd: evt.number_attr(event_key::DELTA_NEUTRALITY_FEE_USD)?,
                 deposit_collateral: evt.number_attr(event_key::DEPOSIT_COLLATERAL)?,
+                deposit_collateral_usd: evt
+                    // For migrations, this data wasn't always present
+                    .try_number_attr(event_key::DEPOSIT_COLLATERAL_USD)?
+                    .unwrap_or_default(),
                 pnl_collateral: evt.number_attr(event_key::PNL)?,
                 pnl_usd: evt.number_attr(event_key::PNL_USD)?,
                 notional_size: evt.number_attr(event_key::NOTIONAL_SIZE)?,

--- a/packages/msg/src/contracts/market/position/closed.rs
+++ b/packages/msg/src/contracts/market/position/closed.rs
@@ -59,6 +59,10 @@ pub struct ClosedPosition {
     /// This includes any updates from collateral being added or removed.
     pub deposit_collateral: Signed<Collateral>,
 
+    /// Deposit collateral in USD, using cost basis analysis.
+    #[serde(default)]
+    pub deposit_collateral_usd: Signed<Usd>,
+
     /// Final active collateral, the amount sent back to the trader on close
     pub active_collateral: Collateral,
 


### PR DESCRIPTION
This was on oversight on my part originally, we do need this field. This PR includes fallback defaults to help with migration, as well as changes to the companion server to use this field when available.