### PR TITLE
Integrate Sentry to bots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.70"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa67157abdfd688a259b6648808757db9347af834624f27ec646da976aee5d"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1019,6 +1019,16 @@ name = "deadpool-runtime"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid 1.4.0",
+]
 
 [[package]]
 name = "der"
@@ -1545,7 +1555,7 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
- "uuid",
+ "uuid 0.7.4",
 ]
 
 [[package]]
@@ -1875,7 +1885,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.2",
+ "rustls 0.21.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1985,9 +1995,9 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix 0.38.3",
@@ -2646,6 +2656,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "resvg",
+ "sentry",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3142,7 +3153,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls 0.21.3",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3155,7 +3166,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -3279,13 +3290,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.1",
  "sct",
 ]
 
@@ -3315,6 +3326,16 @@ name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
 dependencies = [
  "ring",
  "untrusted",
@@ -3472,6 +3493,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
+name = "sentry"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f8ce69326daef9d845c3fd17149bd3dbd7caf5dc65dbbad9f5441a40ee407f"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "rustls 0.20.8",
+ "sentry-core",
+ "tokio",
+ "ureq",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5acbd3da4255938cf0384b6b140e6c07ff65919c26e4d7a989d8d90ee88fa91"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d8587b12c0b8211bb3066979ee57af6e8657e23cf439dc6c8581fd86de24e8"
+dependencies = [
+ "debugid",
+ "getrandom",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.22",
+ "url",
+ "uuid 1.4.0",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
@@ -3578,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+checksum = "8acc4422959dd87a76cb117c191dcbffc20467f06c9100b76721dab370f24d3a"
 dependencies = [
  "itoa",
  "serde",
@@ -3706,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -3806,7 +3872,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "whoami",
 ]
 
@@ -4050,6 +4116,8 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
+ "itoa",
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -4168,7 +4236,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.2",
+ "rustls 0.21.3",
  "tokio",
 ]
 
@@ -4521,6 +4589,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64 0.21.2",
+ "log",
+ "once_cell",
+ "rustls 0.21.3",
+ "rustls-webpki 0.100.1",
+ "url",
+ "webpki-roots 0.23.1",
+]
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4529,6 +4612,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4611,6 +4695,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.5",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+dependencies = [
+ "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -4753,6 +4847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]

--- a/packages/perps-exes/Cargo.toml
+++ b/packages/perps-exes/Cargo.toml
@@ -6,8 +6,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-msg = { path = "../msg", package = "levana_perpswap_cosmos_msg", features = ["bridge"] }
-shared = { path = "../shared", package = "levana_perpswap_cosmos_shared", features = ["chrono"] }
+msg = { path = "../msg", package = "levana_perpswap_cosmos_msg", features = [
+       "bridge",
+] }
+shared = { path = "../shared", package = "levana_perpswap_cosmos_shared", features = [
+       "chrono",
+] }
 serde = { version = "1.0.141", features = ["derive"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9.2"
@@ -30,12 +34,12 @@ reqwest = { version = "0.11.11", default-features = false, features = [
        "gzip",
 ] }
 chrono = { version = "0.4.19", features = ["serde"] }
-axum = { version = "0.6", features = ["headers"]}
+axum = { version = "0.6", features = ["headers"] }
 axum-extra = { version = "0.7", features = ["typed-routing"] }
 tower-http = { version = "0.3.4", features = ["cors", "auth"] }
 futures = "0.3.26"
 tokio-tungstenite = "*"
-tokio-util = {version = "0.7.7", features = ["full"]}
+tokio-util = { version = "0.7.7", features = ["full"] }
 cw-multi-test = "0.16.2"
 rand = "0.8"
 pyth-sdk-cw = "1.0.0"
@@ -47,8 +51,16 @@ thiserror = "1"
 resvg = "0.34"
 axum-macros = "0.3.7"
 mime = "0.3.17"
-sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls", "postgres", "offline"]}
+sqlx = { version = "0.6.3", features = [
+       "runtime-tokio-rustls",
+       "postgres",
+       "offline",
+] }
 itertools = "0.10.5"
+sentry = { version = "0.29", default-features = false, features = [ # Newer sentry require rustc 1.66+
+       "reqwest",
+       "rustls",
+] }
 
 [features]
 default = []

--- a/packages/perps-exes/src/bin/perps-bots/app.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app.rs
@@ -22,6 +22,14 @@ use self::gas_check::GasCheckWallet;
 
 impl AppBuilder {
     pub(crate) async fn start(mut self) -> Result<()> {
+        let family = match &self.app.config.by_type {
+            crate::config::BotConfigByType::Testnet { inner } => inner.contract_family.clone(),
+            crate::config::BotConfigByType::Mainnet { inner } => {
+                format!("Factory address {}", inner.factory)
+            }
+        };
+        sentry::configure_scope(|scope| scope.set_tag("bot-name", family));
+
         // Start the tasks that run on all deployments
         self.start_rest_api();
         self.start_factory_task()?;

--- a/packages/perps-exes/src/bin/perps-bots/cli.rs
+++ b/packages/perps-exes/src/bin/perps-bots/cli.rs
@@ -17,6 +17,9 @@ pub(crate) struct Opt {
         global = true
     )]
     pub(crate) bind: SocketAddr,
+    /// Sentry client key
+    #[arg(short, long, env = "SENTRY_KEY")]
+    pub(crate) client_key: Option<String>,
     /// Override the gRPC URL
     #[clap(long, env = "COSMOS_GRPC")]
     pub(crate) grpc_url: Option<String>,

--- a/packages/perps-exes/src/bin/perps-bots/main.rs
+++ b/packages/perps-exes/src/bin/perps-bots/main.rs
@@ -19,5 +19,15 @@ async fn main_inner() -> Result<()> {
 
     let opt = cli::Opt::parse();
     opt.init_logger();
+    let _guard = opt.client_key.clone().map(|ck| {
+        sentry::init((
+            ck,
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                session_mode: sentry::SessionMode::Request,
+                ..Default::default()
+            },
+        ))
+    });
     opt.into_app_builder().await?.start().await
 }


### PR DESCRIPTION
In current Ops design, services send alerts to Sentry then triggers other function parts. Also Sentry could do some analyzation on error history.

To avoid the quota issue, reduce the messages sent to Sentry, this implenmentation follows `p2s`, only sends state change messages to Sentry, which means on error first occurs, and on error is gone.

The definition of "error occur" is the final `Err` `Result` of a task, after it retries.

The definition of "error gone" is that last time, the task failed, and this time, the task succeeded.