### PR TITLE
Add pid1 image to the bots dockerfile

### DIFF
--- a/.ci/bots/Dockerfile
+++ b/.ci/bots/Dockerfile
@@ -6,6 +6,12 @@ COPY amber.yaml /etc/amber.yaml
 ADD "https://github.com/fpco/amber/releases/download/v0.1.3/amber-x86_64-unknown-linux-musl" "/usr/bin/amber"
 RUN chmod 755 /usr/bin/amber
 
+ADD https://github.com/fpco/pid1/releases/download/v0.1.3.1/pid1 /usr/bin/pid1
+
+RUN chmod +x /usr/bin/pid1
+
 ENV AMBER_YAML=/etc/amber.yaml
+
+ENTRYPOINT [ "pid1" ]
 
 CMD ["/usr/bin/amber", "--amber-yaml", "/etc/amber.yaml", "--unmasked", "exec", "/usr/bin/perps-bots"]


### PR DESCRIPTION
When we deploy a new task definition using Amazon ECS, it is taking quite a bit of time for the new task to come up to life.

When ECS stops a running task, it sends a SIGTERM signal. Right now it takes quites a bit of time which indicates that the signal is likely being ignored. Using pid1, will hopefully solve this issue.