### PR TITLE
perp-1715 | use correct price feed for ETH_BTC

### DIFF
--- a/packages/perps-exes/assets/config-pyth.yaml
+++ b/packages/perps-exes/assets/config-pyth.yaml
@@ -24,9 +24,9 @@ markets:
       # inverted BTC/USD
       {id: "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43", inverted: true }
     ]
-    # ETH_USD (snake_case for compatibility with instantiate message)
+    # BTC_USD (snake_case for compatibility with instantiate message)
     feeds_usd: [
-      {id: "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace", inverted: false }
+      {id: "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43", inverted: false }
     ]
   ETH_USD:
     feeds: [


### PR DESCRIPTION
It was using the ETH price for price_usd, when it needs to be the BTC price.