### PR TITLE
perp-1985 | migrate the Pyth bridge to Hermes

### DIFF
--- a/packages/perps-exes/src/bin/perps-deploy/factory.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/factory.rs
@@ -4,9 +4,11 @@ use cosmos::{Address, CodeId, Contract, HasAddress, HasCosmos, Wallet};
 use msg::contracts::factory::entry::{
     CodeIds, FactoryOwnerResp, MarketInfoResponse, MarketsResp, QueryMsg,
 };
+use msg::contracts::market::entry::NewMarketParams;
 use msg::prelude::*;
 use msg::shutdown::{ShutdownEffect, ShutdownImpact};
 
+#[derive(Clone)]
 pub(crate) struct Factory(Contract);
 
 impl Display for Factory {
@@ -147,6 +149,38 @@ impl Factory {
     pub(crate) async fn query_market_code_id(&self) -> Result<CodeId> {
         let CodeIds { market, .. } = self.0.query(FactoryQueryMsg::CodeIds {}).await?;
         Ok(self.0.get_cosmos().make_code_id(market.u64()))
+    }
+
+    pub(crate) async fn add_market(
+        &self,
+        wallet: &Wallet,
+        new_market: NewMarketParams,
+    ) -> Result<TxResponse> {
+        self.0
+            .execute(
+                wallet,
+                vec![],
+                msg::contracts::factory::entry::ExecuteMsg::AddMarket { new_market },
+            )
+            .await
+    }
+
+    pub(crate) async fn set_price_admin(
+        &self,
+        wallet: &Wallet,
+        market: impl HasAddress,
+        new_admin: impl HasAddress,
+    ) -> Result<TxResponse> {
+        self.0
+            .execute(
+                wallet,
+                vec![],
+                FactoryExecuteMsg::SetMarketPriceAdmin {
+                    market_addr: market.get_address_string().into(),
+                    admin_addr: new_admin.get_address_string().into(),
+                },
+            )
+            .await
     }
 }
 

--- a/packages/perps-exes/src/bin/perps-deploy/testnet/add_market.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/testnet/add_market.rs
@@ -3,7 +3,9 @@ use cosmwasm_std::Decimal256;
 use msg::prelude::*;
 use shared::storage::MarketId;
 
-use crate::{app::PriceSourceConfig, instantiate::AddMarketParams, store_code::PYTH_BRIDGE};
+use crate::{
+    app::PriceSourceConfig, factory::Factory, instantiate::AddMarketParams, store_code::PYTH_BRIDGE,
+};
 
 #[derive(clap::Parser)]
 pub(crate) struct AddMarketOpt {
@@ -22,6 +24,7 @@ impl AddMarketOpt {
     pub(crate) async fn go(self, opt: crate::cli::Opt) -> Result<()> {
         let app = opt.load_app(&self.family).await?;
         let factory = app.tracker.get_factory(&self.family).await?.into_contract();
+        let factory = Factory::from_contract(factory);
         let instantiate_market = app.make_instantiate_market(self.market.clone())?;
         let price_admin = match app.price_source {
             PriceSourceConfig::Pyth(pyth_info) => {


### PR DESCRIPTION
This operates by checking if we're on the old version of the pyth_bridge and, if so, instantiating a fresh bridge and then updating the price admin. Tested on osmodebug and it worked just fine.

Once this is merged in, and once the frontend changes for Hermes are deployed to production, we can begin migrating all the other testnet contracts and updating their bots. Then the final step will be doing this migration process for mainnet. In that case, I'll probably do the migration steps more manually.