### PR TITLE
PERP-2120 | price bot update

### DIFF
--- a/packages/perps-exes/assets/config-testnet.yaml
+++ b/packages/perps-exes/assets/config-testnet.yaml
@@ -177,3 +177,16 @@ overrides:
     traders: 1
     default-market-ids:
       - ETH_USD
+  # osmoci:
+  #   wallet-manager-address: osmo12vhejqqdgnszlcs7nqdvlx3p5eqyudfslevx3k
+  #   price: true
+  #   crank: false
+  #   liquidity: false
+  #   utilization: false
+  #   balance: false
+  #   traders: 1
+  #   default-market-ids:
+  #     - ATOM_USD
+  #     - OSMO_USDC
+  #     - ETH_BTC
+  #     - BTC_USD

--- a/packages/perps-exes/src/bin/perps-bots/util/oracle.rs
+++ b/packages/perps-exes/src/bin/perps-bots/util/oracle.rs
@@ -85,34 +85,13 @@ impl Oracle {
         })
     }
 
-    pub async fn query_price(&self, _age_tolerance_seconds: u32) -> Result<PricePoint> {
-        todo!()
-        // self.bridge
-        //     .query(BridgeQueryMsg::MarketPrice {
-        //         age_tolerance_seconds,
-        //     })
-        //     .await
-    }
-
-    pub async fn prev_market_price_timestamp(&self, _market_id: &MarketId) -> Result<Timestamp> {
-        todo!()
-        // let res = self
-        //     .bridge
-        //     .query_raw(map_key(PYTH_PREV_MARKET_PRICE, market_id))
-        //     .await?;
-        // let price: MarketPrice = serde_json::from_slice(&res)?;
-        // Ok(Timestamp::from_seconds(
-        //     price.latest_price_publish_time.try_into()?,
-        // ))
-    }
-
     pub async fn get_latest_price(
         &self,
         client: &reqwest::Client,
     ) -> Result<(PriceBaseInQuote, PriceCollateralInUsd)> {
         match &self.spot_price_config {
             SpotPriceConfig::Manual { .. } => {
-                unimplemented!("FIXME: support manual oracle w/ contract query")
+                bail!("Manual markets do not use an oracle")
             }
             SpotPriceConfig::Oracle {
                 feeds, feeds_usd, ..
@@ -129,7 +108,6 @@ impl Oracle {
     }
 }
 
-// FIXME: move out of pyth, handle more than just pyth
 async fn price_helper(
     client: &reqwest::Client,
     pyth: Option<&PythOracle>,

--- a/packages/perps-exes/src/contracts/market.rs
+++ b/packages/perps-exes/src/contracts/market.rs
@@ -409,6 +409,18 @@ impl MarketContract {
             .await
     }
 
+    pub fn get_crank_msg(&self, wallet: &Wallet, execs: Option<u32>) -> Result<MsgExecuteContract> {
+        Ok(MsgExecuteContract {
+            sender: wallet.get_address_string(),
+            contract: self.get_address_string(),
+            msg: serde_json::to_vec(&MarketExecuteMsg::Crank {
+                execs,
+                rewards: None,
+            })?,
+            funds: Vec::new(),
+        })
+    }
+
     pub async fn update_max_gains(
         &self,
         wallet: &Wallet,


### PR DESCRIPTION
This doesn't yet do the optimization of updating all markets at once... the intent is to get the bots back on their feet with correct logic, and then a subsequent PR can improve things

Was mostly just moving things around since:

1. We no longer have a price storage independent of the market price storage (publish_time is just a field that's available on PricePoint)

2. To cause a market append_price, we crank