### PR TITLE
add axlETH_USD for ci deploys

### DIFF
--- a/packages/perps-exes/assets/config-testnet.yaml
+++ b/packages/perps-exes/assets/config-testnet.yaml
@@ -92,6 +92,7 @@ deployments:
       - OSMO_USDC
       - ETH_BTC
       - BTC_USD
+      - axlETH_USD
   debug:
     # Seed phrase: soldier speak spawn sword vivid robot brand stage promote pride grant bench degree bulk armor now sketch extend wheel echo figure net wedding unveil
     wallet-manager-address: levana19ta8kepflecc7n2rdruduj9ydt72z2xy0gl5e9


### PR DESCRIPTION
sorry @lvn-rusty-dragon - on further thought, I think we should have this in the CI deploys, since axlETH_USD does behave just a little bit differently in our ecosystem, e.g. the frontend mapping it to ETH_USD