### PR TITLE
bots: Fix data race between threads

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/justfile
+++ b/packages/perps-exes/src/bin/perps-bots/justfile
@@ -6,4 +6,4 @@ LEVANA_BOTS_FACTORY := "osmo1aakfpghcanxtc45gpqlx8j3rq0zcpyf49qmhm9mdjrfx036h4z5
 
 # Run application
 run:
-	env LEVANA_BOTS_FACTORY={{LEVANA_BOTS_FACTORY}} LEVANA_BOTS_NUM_BLOCKS=40 COSMOS_NETWORK=osmosis-local LEVANA_BOTS_SEED_PHRASE="bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort"  cargo run --verbose --bin perps-bots -- mainnet --crank-rewards {{LEVANA_BOTS_FACTORY}} --rpc-endpoint http://localhost:1317
+	env LEVANA_BOTS_FACTORY={{LEVANA_BOTS_FACTORY}} LEVANA_BOTS_NUM_BLOCKS=40 COSMOS_NETWORK=osmosis-local LEVANA_BOTS_SEED_PHRASE="bottom loan skill merry east cradle onion journey palm apology verb edit desert impose absurd oil bubble sweet glove shallow size build burst effort"  cargo run --verbose --bin perps-bots -- mainnet --crank-rewards {{LEVANA_BOTS_FACTORY}} --rpc-endpoint http://localhost:1317 --min-gas 1 --min-gas-refill 1

--- a/packages/perps-exes/src/bin/perps-bots/watcher.rs
+++ b/packages/perps-exes/src/bin/perps-bots/watcher.rs
@@ -8,12 +8,12 @@ use axum::http::HeaderValue;
 use axum::response::IntoResponse;
 use axum::{async_trait, Json};
 use chrono::{DateTime, Duration, Utc};
-use once_cell::sync::OnceCell;
 use perps_exes::build_version;
 use perps_exes::config::{TaskConfig, WatcherConfig};
 use rand::Rng;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::StatusCode;
+use tokio::sync::OnceCell;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 
@@ -732,6 +732,11 @@ struct RenderedStatus {
 impl TaskStatuses {
     async fn statuses(&self, selected_label: Option<TaskLabel>) -> Vec<RenderedStatus> {
         let mut all_statuses = vec![];
+
+        while !self.statuses.initialized() {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await
+        }
+
         for (label, status) in self
             .statuses
             .get()


### PR DESCRIPTION
While investigating why bots where taking a huge amount of time to come up when newly deployed in ECS, I found out that the newly launched tasks were actually failing (I observed this in both the sandbox as well as the recently deployed new tasks in mainnet by you).

This was the captured logs:

```
October 20, 2023 at 12:59 (UTC+5:30)	/logging.sh: line 8: 13 Aborted (core dumped) ${cmd[@]} 2>&1	bots
October 20, 2023 at 12:59 (UTC+5:30)	14 Done | tee >(split -l 100000 -)	bots
October 20, 2023 at 12:59 (UTC+5:30)	[2m2023-10-20T07:29:29.267509Z[0m [32m INFO[0m [2mperps_bots::endpoints[0m[2m:[0m Launching server	bots
October 20, 2023 at 12:59 (UTC+5:30)	thread 'tokio-runtime-worker' panicked at 'Status map isn't available yet', packages/perps-exes/src/bin/perps-bots/watcher.rs:738:14	bots
October 20, 2023 at 12:59 (UTC+5:30)	note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace	bots
October 20, 2023 at 12:59 (UTC+5:30)	[2m2023-10-20T07:29:25.627991Z[0m [32m INFO[0m [2mperps_bots::app::types[0m[2m:[0m Overriding gRPC URL to: https://osmo-priv-grpc.kingnodes.com	bots
October 20, 2023 at 12:59 (UTC+5:30)	[2m2023-10-20T07:29:25.627841Z[0m [32m INFO[0m [2mperps_bots::app::types[0m[2m:[0m Creating connection to network osmosis-mainnet	bots
October 20, 2023 at 12:59 (UTC+5:30)	[2m2023-10-20T07:29:25.496979Z[0m [32m INFO[0m [2mperps_bots::cli[0m[2m:[0m Initialized Logging	bots
October 20, 2023 at 12:59 (UTC+5:30)	pid1-rs: Process not running as Pid 1: PID 13
```

As you can see that the tokio runtime panics. The panic message is quite helpful on what's happening. This PR fixes it.