### PR TITLE
perp-2386 | add a suppress for task output

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/app/balance.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/balance.rs
@@ -36,10 +36,7 @@ impl WatchedTaskPerMarket for TrackBalance {
     ) -> Result<WatchedTaskOutput> {
         check_balance_single(&market.market)
             .await
-            .map(|()| WatchedTaskOutput {
-                skip_delay: false,
-                message: "Market is in balance".to_owned(),
-            })
+            .map(|()| WatchedTaskOutput::new("Market is in balance".to_owned()))
     }
 }
 
@@ -105,10 +102,9 @@ async fn single_market(
     if instant_abs * Decimal256::from_str("3").unwrap()
         <= status.config.delta_neutrality_fee_cap.raw()
     {
-        return Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: "Protocol is within 1/3 of the cap".to_owned(),
-        });
+        return Ok(WatchedTaskOutput::new(
+            "Protocol is within 1/3 of the cap".to_owned(),
+        ));
     }
 
     let direction = if instant.is_negative() {
@@ -127,10 +123,7 @@ async fn single_market(
                 pos.id
             );
             market.close_position(&worker.wallet, pos.id).await?;
-            return Ok(WatchedTaskOutput {
-                skip_delay: true,
-                message: "Closed a position".to_owned(),
-            });
+            return Ok(WatchedTaskOutput::new("Closed a position").skip_delay());
         }
     }
 
@@ -224,8 +217,5 @@ async fn single_market(
         )
         .await?;
 
-    Ok(WatchedTaskOutput {
-        skip_delay: true,
-        message: "Opened a new position to balance the protocol".to_owned(),
-    })
+    Ok(WatchedTaskOutput::new("Opened a new position to balance the protocol").skip_delay())
 }

--- a/packages/perps-exes/src/bin/perps-bots/app/factory.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/factory.rs
@@ -95,10 +95,7 @@ async fn update(app: &App) -> Result<WatchedTaskOutput> {
                 .await?
         }
     };
-    let output = WatchedTaskOutput {
-        skip_delay: false,
-        message,
-    };
+    let output = WatchedTaskOutput::new(message);
     app.set_factory_info(info).await;
     Ok(output)
 }

--- a/packages/perps-exes/src/bin/perps-bots/app/gas_check.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/gas_check.rs
@@ -216,9 +216,11 @@ impl GasCheck {
         }
 
         if errors.is_empty() {
-            Ok(WatchedTaskOutput {
-                message: balances.join("\n"),
-                skip_delay,
+            let output = WatchedTaskOutput::new(balances.join("\n"));
+            Ok(if skip_delay {
+                output.skip_delay()
+            } else {
+                output
             })
         } else {
             errors.append(&mut balances);

--- a/packages/perps-exes/src/bin/perps-bots/app/liquidity_transaction.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/liquidity_transaction.rs
@@ -93,14 +93,12 @@ async fn check_liquidity_transaction_alert(
             DeltaChange::RiseUp => "increased",
             DeltaChange::RiseDown => "decreased",
         };
-        Ok(WatchedTaskOutput { skip_delay: false, message: format!("Total liquidity {msg} by {percentage_change}% between height {historical_height} and {latest_height}")})
+        Ok(WatchedTaskOutput::new(format!("Total liquidity {msg} by {percentage_change}% between height {historical_height} and {latest_height}")))
     } else {
-        Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: format!(
+        Ok(WatchedTaskOutput::new(
+            format!(
                 "Total liqudity between heights of {} is under the expected delta (Percentage change: {percentage_change}%)",
                 mainnet.liquidity_transaction.number_of_blocks
-            ),
-        })
+            )))
     }
 }

--- a/packages/perps-exes/src/bin/perps-bots/app/price.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/price.rs
@@ -182,10 +182,7 @@ async fn run_price_update(worker: &mut Worker, app: Arc<App>) -> Result<WatchedT
     if is_error {
         Err(anyhow::anyhow!({ msg }))
     } else {
-        Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: msg,
-        })
+        Ok(WatchedTaskOutput::new(msg))
     }
 }
 

--- a/packages/perps-exes/src/bin/perps-bots/app/rpc_health.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/rpc_health.rs
@@ -44,10 +44,7 @@ async fn check(app: &App, endpoint: Arc<String>) -> Result<WatchedTaskOutput> {
     let delta = rpc_height.abs_diff(grpc_height);
 
     if delta < ALLOWED_DELTA {
-        Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: format!("RPC endpoint {endpoint} looks healthy. Delta: {delta}. RPC height: {rpc_height}. gRPC height: {grpc_height}.")
-        })
+        Ok(WatchedTaskOutput::new(format!("RPC endpoint {endpoint} looks healthy. Delta: {delta}. RPC height: {rpc_height}. gRPC height: {grpc_height}.")))
     } else {
         Err(anyhow::anyhow!("RPC endpoint {endpoint} has too high a block height delta {delta}. RPC height: {rpc_height}. gRPC height: {grpc_height}."))
     }

--- a/packages/perps-exes/src/bin/perps-bots/app/stale.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/stale.rs
@@ -51,10 +51,7 @@ impl WatchedTaskPerMarketParallel for Stale {
     ) -> Result<WatchedTaskOutput> {
         self.check_stale_single(&market.market, app)
             .await
-            .map(|message| WatchedTaskOutput {
-                skip_delay: false,
-                message,
-            })
+            .map(WatchedTaskOutput::new)
     }
 }
 

--- a/packages/perps-exes/src/bin/perps-bots/app/stats.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/stats.rs
@@ -28,10 +28,7 @@ impl WatchedTaskPerMarket for Stats {
     ) -> Result<WatchedTaskOutput> {
         let status = market.market.status().await?;
         let market_stats = MarketStats { status };
-        Ok(WatchedTaskOutput {
-            message: market_stats.to_string(),
-            skip_delay: false,
-        })
+        Ok(WatchedTaskOutput::new(market_stats.to_string()))
     }
 }
 

--- a/packages/perps-exes/src/bin/perps-bots/app/stats_alert.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/stats_alert.rs
@@ -34,10 +34,7 @@ impl WatchedTaskPerMarket for StatsAlert {
     ) -> Result<WatchedTaskOutput> {
         check_stats_alert(&market.market, &self.mainnet)
             .await
-            .map(|()| WatchedTaskOutput {
-                skip_delay: false,
-                message: "Market stats are within acceptable parameters".to_owned(),
-            })
+            .map(|()| WatchedTaskOutput::new("Market stats are within acceptable parameters"))
     }
 }
 

--- a/packages/perps-exes/src/bin/perps-bots/app/total_deposits.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/total_deposits.rs
@@ -93,14 +93,13 @@ async fn check_liquidity_transaction_alert(
             DeltaChange::RiseUp => "increased",
             DeltaChange::RiseDown => "decreased",
         };
-        Ok(WatchedTaskOutput { skip_delay: false, message: format!("Total deposits {msg} by {percentage_change}% between height {historical_height} and {latest_height}")})
+        Ok(WatchedTaskOutput::new(format!("Total deposits {msg} by {percentage_change}% between height {historical_height} and {latest_height}")))
     } else {
-        Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: format!(
+        Ok(WatchedTaskOutput::new(
+            format!(
                 "Total deposits between heights of {} is under the expected delta (Percentage change: {percentage_change}%)",
                 mainnet.liquidity_transaction.number_of_blocks
             ),
-        })
+        ))
     }
 }

--- a/packages/perps-exes/src/bin/perps-bots/app/trader.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/trader.rs
@@ -118,10 +118,7 @@ async fn single_market(
 
     let total = status.liquidity.total_collateral();
     if total.is_zero() {
-        return Ok(WatchedTaskOutput {
-            skip_delay: false,
-            message: "No liquidity available".to_owned(),
-        });
+        return Ok(WatchedTaskOutput::new("No liquidity available".to_owned()));
     }
     let util_ratio = status
         .liquidity
@@ -229,8 +226,5 @@ async fn single_market(
             format!("Opened new position: {deposit} {direction:?} {leverage}x")
         }
     };
-    Ok(WatchedTaskOutput {
-        skip_delay: false,
-        message,
-    })
+    Ok(WatchedTaskOutput::new(message))
 }

--- a/packages/perps-exes/src/bin/perps-bots/app/ultra_crank.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/ultra_crank.rs
@@ -74,10 +74,7 @@ impl App {
         } = market.status().await?;
         if next_crank.is_none() {
             *activated = false;
-            return Ok(WatchedTaskOutput {
-                skip_delay: false,
-                message: "No crank messages waiting".to_owned(),
-            });
+            return Ok(WatchedTaskOutput::new("No crank messages waiting"));
         }
         let last_crank_completed = last_crank_completed
             .context("No cranks have completed")?
@@ -88,10 +85,9 @@ impl App {
         if age >= testnet.seconds_till_ultra.into() {
             *activated = true;
         } else if !*activated {
-            return Ok(WatchedTaskOutput {
-                skip_delay: false,
-                message: format!("Crank is only {age} seconds out of date, not doing anything"),
-            });
+            return Ok(WatchedTaskOutput::new(format!(
+                "Crank is only {age} seconds out of date, not doing anything"
+            )));
         }
         let res = market
             .crank_single(
@@ -102,9 +98,9 @@ impl App {
                     .map(|a| a.get_address_string().into()),
             )
             .await?;
-        Ok(WatchedTaskOutput {
-            skip_delay: true,
-            message: format!("Completed an ultracrank in {}", res.txhash),
-        })
+        Ok(WatchedTaskOutput::new(format!(
+            "Completed an ultracrank in {}",
+            res.txhash
+        )))
     }
 }


### PR DESCRIPTION
This moves WatchedTaskOutput to use a builder pattern, which creates a lot of noise in the PR. The core concept is adding a new suppress field which, when true, will avoid overwriting old statuses. The purpose for now is that, when doing crank run, we will not wipe out the useful information of the last transaction sent with useless "nothing interesting happened" messages.