### PR TITLE
PERP-2419 | nomic mainnet config

### DIFF
--- a/packages/perps-exes/assets/config-chain.yaml
+++ b/packages/perps-exes/assets/config-chain.yaml
@@ -44,6 +44,9 @@ osmosis-mainnet:
     TIA:
       denom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
       decimal-places: 6
+    nBTC:
+      denom: ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F
+      decimal-places: 14
 osmosis-testnet:
   gas-decimals: 6
   spot-price: 

--- a/packages/perps-exes/assets/config-price.yaml
+++ b/packages/perps-exes/assets/config-price.yaml
@@ -181,6 +181,13 @@ networks:
       feeds-usd: [
         !pyth { key: "BTC_USD", inverted: false }
       ]
+    nBTC_USD:
+      feeds: [
+        !pyth { key: "BTC_USD", inverted: false }
+      ]
+      feeds-usd: [
+        !pyth { key: "BTC_USD", inverted: false }
+      ]
     OSMO_USD:
       feeds: [
         !pyth { key: "OSMO_USD", inverted: false}


### PR DESCRIPTION
with this in place, result of `cargo run --bin perps-deploy mainnet add-market --factory osmomainnet1 --market-id nBTC_USD` works

