### PR TITLE
perps-qa wallet scraping: Ability to specify optional start height

### DIFF
--- a/packages/perps-exes/src/bin/perps-qa/justfile
+++ b/packages/perps-exes/src/bin/perps-qa/justfile
@@ -4,4 +4,4 @@ default:
 
 # Generate wallet report
 gen-wallet-report:
-	cargo run --bin perps-qa wallet-report --wallet-addr inj13lzkzpuraxxmm5nefac64fpqwdacjd7jrr0arh
+	env COSMOS_GRPC="https://sentry.chain.grpc.injective.network" cargo run --bin perps-qa wallet-report --start-height 52263000 --total-datapoints 10000 --lookback-height-count 5000 --wallet-addr inj1aq8sknt5u54rduvqtquq0amk6adqwl34txxngp


### PR DESCRIPTION
This is useful when you want to start the query from an arbitrary height instead of the latest height.