### PR TITLE
Remove a map_err

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/main.rs
+++ b/packages/perps-exes/src/bin/perps-bots/main.rs
@@ -50,5 +50,4 @@ fn main_inner() -> Result<()> {
             ))?;
             opt.into_app_builder().await?.start(listener).await
         })
-        .map_err(anyhow::Error::msg)
 }


### PR DESCRIPTION
@lvn-hasky-dragon without this change, we end up missing out on the root cause for why the process exited. I see this lined was added in:

https://github.com/Levana-Protocol/levana-perps/commit/64183f79dba91f045b53a929c4b833d57c3c4ac7#diff-dffb959ce05af57968b48d296ef634e0408d5960d51b3ce5d0f551659aaea487R49

Can you clarify if we need this for tracing support?