### PR TITLE
bots: Make the node health report more readable

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/watcher.rs
+++ b/packages/perps-exes/src/bin/perps-bots/watcher.rs
@@ -13,6 +13,7 @@ use perps_exes::build_version;
 use perps_exes::config::{TaskConfig, WatcherConfig};
 use rand::Rng;
 
+use serde::Serialize;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
@@ -1093,7 +1094,13 @@ struct StatusTemplate<'a> {
     live_since: DateTime<Utc>,
     now: DateTime<Utc>,
     alert: bool,
-    node_health: String,
+    node_health: Vec<NodeDescription>,
+}
+
+#[derive(Serialize)]
+struct NodeDescription {
+    node_url: String,
+    description: String,
 }
 
 impl TaskStatuses {
@@ -1121,7 +1128,16 @@ impl TaskStatuses {
             live_since: app.live_since,
             now: Utc::now(),
             alert,
-            node_health: app.cosmos.node_health_report().to_string(),
+            node_health: app
+                .cosmos
+                .node_health_report()
+                .nodes
+                .into_iter()
+                .map(|item| NodeDescription {
+                    description: item.to_string(),
+                    node_url: item.grpc_url.to_string(),
+                })
+                .collect(),
         }
     }
 }

--- a/packages/perps-exes/templates/status.html
+++ b/packages/perps-exes/templates/status.html
@@ -41,6 +41,17 @@
         pre {
             white-space: pre-wrap;
         }
+
+	.node-health {
+	    border: 1px solid #ddd;
+	    border-radius: 5px;
+	    padding: 10px;
+	    margin-bottom: 10px;
+	}
+
+	.node-health p:last-child {
+	    margin-bottom: 0;
+	}
     </style>
   </head>
   <body>
@@ -79,7 +90,11 @@
             </tbody>
         </table>
 
-        <pre>{{ node_health }}</pre>
+	<div class="node-health">
+	  {% for node in node_health %}
+	    <p>{{ node.description }}</p>
+	  {% endfor %}
+	</div>
 
         {% for status in statuses %}
           <div class="panel panel-default">


### PR DESCRIPTION
It will look like this which some gap between each nodes to make thing easier to read:

![health_node_report](https://github.com/Levana-Protocol/levana-perps/assets/131741584/c7eb4886-6d91-4b25-9ba2-74ae12b540a5)
