### PR TITLE
perp-2754 | ignore errors after epoch

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/app/types.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/types.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use bigdecimal::BigDecimal;
@@ -10,6 +10,7 @@ use chrono::Utc;
 use cosmos::{Address, HasAddress};
 use cosmos::{Coin, Cosmos};
 use cosmos::{DynamicGasMultiplier, Wallet};
+use parking_lot::Mutex;
 use perps_exes::config::GasAmount;
 use reqwest::Client;
 use serde::Serialize;
@@ -134,6 +135,7 @@ pub(crate) struct App {
     pub(crate) endpoint_edge: String,
     pub(crate) pyth_market_hours: PythMarketHours,
     pub(crate) opt: Opt,
+    pub(crate) epoch_last_seen: Mutex<Option<Instant>>,
 }
 
 /// Helper data structure for building up an application.
@@ -231,6 +233,7 @@ impl Opt {
             endpoint_edge: self.pyth_endpoint_edge,
             pyth_market_hours: Default::default(),
             opt,
+            epoch_last_seen: Mutex::new(None),
         };
         let app = Arc::new(app);
         let mut builder = AppBuilder {

--- a/packages/perps-exes/src/bin/perps-bots/cli.rs
+++ b/packages/perps-exes/src/bin/perps-bots/cli.rs
@@ -156,6 +156,13 @@ pub(crate) struct MainnetOpt {
     /// How many crank wallets to use
     #[clap(long, env = "LEVANA_BOTS_CRANK_WALLETS", default_value_t = 4)]
     pub(crate) crank_wallets: u64,
+    /// How many seconds to ignore errors after an epoch
+    #[clap(
+        long,
+        env = "LEVANA_BOTS_IGNORE_ERRORS_AFTER_EPOCH_SECONDS",
+        default_value_t = 300
+    )]
+    pub(crate) ignore_errors_after_epoch_seconds: u32,
 }
 
 impl Opt {

--- a/packages/perps-exes/src/bin/perps-bots/config.rs
+++ b/packages/perps-exes/src/bin/perps-bots/config.rs
@@ -72,6 +72,8 @@ pub(crate) struct BotConfig {
     /// Wallet used to refill gas for other wallets
     pub(crate) gas_wallet: Arc<Wallet>,
     pub(crate) ignored_markets: HashSet<MarketId>,
+    /// How many seconds to ignore errors after an epoch
+    pub(crate) ignore_errors_after_epoch_seconds: u32,
 }
 
 impl BotConfig {
@@ -205,6 +207,8 @@ impl Opt {
             min_gas_in_gas_wallet: partial.min_gas_in_gas_wallet,
             gas_wallet,
             ignored_markets: self.ignored_markets.iter().cloned().collect(),
+            // Never used on testnet, just setting a reasonable default
+            ignore_errors_after_epoch_seconds: 300,
         };
 
         Ok((config, Some(faucet_bot_runner)))
@@ -232,6 +236,7 @@ impl Opt {
             crank_rewards,
             rpc_endpoint,
             crank_wallets,
+            ignore_errors_after_epoch_seconds,
         }: &MainnetOpt,
     ) -> Result<BotConfig> {
         let hrp = network.get_address_hrp();
@@ -285,6 +290,7 @@ impl Opt {
             min_gas_in_gas_wallet: *min_gas_refill,
             gas_wallet: Arc::new(gas_wallet),
             ignored_markets: self.ignored_markets.iter().cloned().collect(),
+            ignore_errors_after_epoch_seconds: *ignore_errors_after_epoch_seconds,
         })
     }
 }


### PR DESCRIPTION
This is a slightly hacky approach, since (1) it relies on the bots having been running during the epoch to populate a variable and (2) it also relies on an error having occured during that period. I think this will end up being Good Enough in all cases we care about, and is much easier to implement than other approaches I could think of, so I wanted to try this out first and confirm it works as expected.

This should _not_ get deployed before the weekend, it should only go live Sunday the earliest and we should manually confirm that it works as expected at the next epoch.