### PR TITLE
perp-2817 | crank fee surcharge

### DIFF
--- a/contracts/market/src/state/config.rs
+++ b/contracts/market/src/state/config.rs
@@ -60,6 +60,7 @@ pub(crate) fn update_config(
         delta_neutrality_fee_cap,
         delta_neutrality_fee_tax,
         crank_fee_charged,
+        crank_fee_surcharge,
         crank_fee_reward,
         minimum_deposit_usd: minimum_deposit,
         liquifunding_delay_fuzz_seconds,
@@ -148,7 +149,9 @@ pub(crate) fn update_config(
     if let Some(x) = crank_fee_charged {
         config.crank_fee_charged = x;
     }
-
+    if let Some(x) = crank_fee_surcharge {
+        config.crank_fee_surcharge = x;
+    }
     if let Some(x) = crank_fee_reward {
         config.crank_fee_reward = x;
     }

--- a/contracts/market/src/state/crank.rs
+++ b/contracts/market/src/state/crank.rs
@@ -120,17 +120,21 @@ impl State<'_> {
         .into();
 
         let mut actual = vec![];
+        let mut fees_earned = 0;
         for _ in 0..n_execs {
             match self.crank_work(ctx.storage)? {
                 None => break,
                 Some(work_info) => {
                     actual.push(work_info.clone());
+                    if work_info.receives_crank_rewards() {
+                        fees_earned += 1;
+                    }
                     self.crank_exec(ctx, work_info)?;
                 }
             };
         }
 
-        self.allocate_crank_fees(ctx, rewards, actual.len().try_into()?)?;
+        self.allocate_crank_fees(ctx, rewards, fees_earned)?;
         ctx.response_mut().add_event(CrankExecBatchEvent {
             requested: n_execs,
             actual,

--- a/packages/msg/src/contracts/market/config.rs
+++ b/packages/msg/src/contracts/market/config.rs
@@ -65,6 +65,16 @@ pub struct Config {
     pub delta_neutrality_fee_tax: Decimal256,
     /// The crank fee to be paid into the system, in collateral
     pub crank_fee_charged: Usd,
+    /// The crank surcharge charged for every 10 items in the deferred execution queue.
+    ///
+    /// This is intended to create backpressure in times of high congestion.
+    ///
+    /// For every 10 items in the deferred execution queue, this amount is added to the
+    /// crank fee charged on performing a deferred execution message.
+    ///
+    /// This is only charged while adding new items to the queue, not when performing
+    /// ongoing tasks like liquifunding or liquidations.
+    pub crank_fee_surcharge: Usd,
     /// The crank fee to be sent to crankers, in collateral
     pub crank_fee_reward: Usd,
     /// Minimum deposit collateral, given in USD
@@ -167,6 +177,7 @@ impl Config {
             delta_neutrality_fee_cap: ConfigDefaults::delta_neutrality_fee_cap(),
             delta_neutrality_fee_tax: ConfigDefaults::delta_neutrality_fee_tax(),
             crank_fee_charged: ConfigDefaults::crank_fee_charged(),
+            crank_fee_surcharge: ConfigDefaults::crank_fee_surcharge(),
             crank_fee_reward: ConfigDefaults::crank_fee_reward(),
             minimum_deposit_usd: ConfigDefaults::minimum_deposit_usd(),
             liquifunding_delay_fuzz_seconds: ConfigDefaults::liquifunding_delay_fuzz_seconds(),
@@ -347,6 +358,7 @@ pub struct ConfigUpdate {
     pub delta_neutrality_fee_cap: Option<NumberGtZero>,
     pub delta_neutrality_fee_tax: Option<Decimal256>,
     pub crank_fee_charged: Option<Usd>,
+    pub crank_fee_surcharge: Option<Usd>,
     pub crank_fee_reward: Option<Usd>,
     pub minimum_deposit_usd: Option<Usd>,
     pub liquifunding_delay_fuzz_seconds: Option<u32>,
@@ -380,6 +392,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ConfigUpdate {
             delta_neutrality_fee_cap: u.arbitrary()?,
             delta_neutrality_fee_tax: arbitrary_decimal_256_option(u)?,
             crank_fee_charged: u.arbitrary()?,
+            crank_fee_surcharge: u.arbitrary()?,
             crank_fee_reward: u.arbitrary()?,
             minimum_deposit_usd: u.arbitrary()?,
             liquifunding_delay_fuzz_seconds: None,
@@ -415,6 +428,7 @@ impl From<Config> for ConfigUpdate {
             delta_neutrality_fee_cap: Some(src.delta_neutrality_fee_cap),
             delta_neutrality_fee_tax: Some(src.delta_neutrality_fee_tax),
             crank_fee_charged: Some(src.crank_fee_charged),
+            crank_fee_surcharge: Some(src.crank_fee_surcharge),
             crank_fee_reward: Some(src.crank_fee_reward),
             minimum_deposit_usd: Some(src.minimum_deposit_usd),
             liquifunding_delay_fuzz_seconds: Some(src.liquifunding_delay_fuzz_seconds),

--- a/packages/msg/src/contracts/market/config/defaults.rs
+++ b/packages/msg/src/contracts/market/config/defaults.rs
@@ -80,8 +80,11 @@ impl ConfigDefaults {
     pub fn crank_fee_charged() -> Usd {
         "0.01".parse().unwrap()
     }
+    pub fn crank_fee_surcharge() -> Usd {
+        "0.005".parse().unwrap()
+    }
     pub fn crank_fee_reward() -> Usd {
-        "0.001".parse().unwrap()
+        "0.005".parse().unwrap()
     }
     pub fn minimum_deposit_usd() -> Usd {
         "5".parse().unwrap()

--- a/packages/msg/src/contracts/market/crank.rs
+++ b/packages/msg/src/contracts/market/crank.rs
@@ -52,6 +52,28 @@ pub enum CrankWorkInfo {
     },
 }
 
+impl CrankWorkInfo {
+    /// Should a cranker receive rewards for performing this action?
+    ///
+    /// We generally want to give out rewards for actions that are directly
+    /// user initiated and will be receiving a crank fee paid into the system. Actions
+    /// which are overall protocol maintenance without a specific user action may be
+    /// unfunded. A simple "attack" we want to avoid is a cranker flooding the system
+    /// with unnecessary price updates + cranks to continue making a profit off of
+    /// "Completed" items.
+    pub fn receives_crank_rewards(&self) -> bool {
+        match self {
+            CrankWorkInfo::CloseAllPositions { .. }
+            | CrankWorkInfo::ResetLpBalances {}
+            | CrankWorkInfo::Completed { .. } => false,
+            CrankWorkInfo::Liquifunding { .. }
+            | CrankWorkInfo::Liquidation { .. }
+            | CrankWorkInfo::DeferredExec { .. }
+            | CrankWorkInfo::LimitOrder { .. } => true,
+        }
+    }
+}
+
 /// Events related to the crank
 pub mod events {
     use std::borrow::Cow;


### PR DESCRIPTION
The overall purpose of these changes is to incentivize cranking and disincentivize flooding the deferred execution queue. Changes:

* Increase the crank fee reward default value from a tenth of a cent to half a cent
* Mark some crank items (close all positions, reset LP balances, and completing a price update) as not receiving a reward
* Adding a "surcharge" that is only charged when queueing a new work item on the deferred execution queue