### PR TITLE
Potential deadlock fix: No request timeout for /healthz and /status page

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/endpoints/mod.rs
+++ b/packages/perps-exes/src/bin/perps-bots/endpoints/mod.rs
@@ -48,17 +48,18 @@ pub(crate) async fn start_rest_api(
         .route("/", get(common::homepage))
         .route("/factory", get(factory::factory))
         .route("/frontend-config", get(factory::factory))
-        .route("/healthz", get(common::healthz))
         .route("/build-version", get(common::build_version))
         .route("/api/faucet", post(faucet::bot))
-        .route("/status", get(status::all))
         .route("/carry", get(carry::carry))
         .route("/status/:label", get(status::single))
         .route("/markets", get(markets::markets))
         .route("/debug/gas-refill", get(debug::gas_refill))
         .route("/debug/fund-usage", get(debug::fund_usage))
         .with_state(RestApp { app, statuses })
-        .layer(service_builder);
+        .layer(service_builder)
+        .route("/healthz", get(common::healthz))
+        .route("/status", get(status::all));
+
 
     tracing::info!("Launching server");
 


### PR DESCRIPTION
Lookink at the logs, there is a heavy correlation between the time when we see the deadlock notification in slack and when the bots ECS task is marked as unhealthy and is stopped by the ECS engine.

And these health check failurs are happening because of Request timed out.