### PR TITLE
PERP 2660: Bots cache

### DIFF
--- a/.github/workflows/bots.yaml
+++ b/.github/workflows/bots.yaml
@@ -2,6 +2,9 @@ name: Bots Docker Image
 
 on:
   workflow_dispatch:
+  schedule:
+    # For cache
+    - cron: "*/5 * * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,3 +50,4 @@ jobs:
         run: just build-bots-image
       - name: Push image
         run: just push-bots-image
+        if: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
I'm hoping that this will fix the cache issue, let's see.

I believe the default branch doesn't have cache, so when we trigger a run - we don't get any cache.