### PR TITLE
perp-2953 | initial milkTIA config

### DIFF
--- a/packages/perps-exes/assets/config-price.yaml
+++ b/packages/perps-exes/assets/config-price.yaml
@@ -457,6 +457,16 @@ networks:
         !stride { denom: "ibc/FE41A73457712D192810690BC19D8915EF3608579D684B27BC68FC1021996590", inverted: false, age_tolerance: 31536000 },
         !pyth { key: "OSMO_USD", inverted: false }
       ]
+    milkTIA_USD:
+      stride-contract: osmo1jlm7dglrwfk073r2mgta66sf27htceaklx0qprlm0pupfv632p6s3mzckj
+      feeds: [
+        !pyth { key: "TIA_USD", inverted: false },
+        !stride { denom: "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA", inverted: false, age_tolerance: 31536000 }
+      ]
+      feeds-usd: [
+        !pyth { key: "TIA_USD", inverted: false },
+        !stride { denom: "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA", inverted: false, age_tolerance: 31536000 }
+      ]
     OSMO_USDC:
       feeds: [
         !pyth { key: "OSMO_USD", inverted: false },

--- a/packages/perps-exes/assets/market-config-updates.yaml
+++ b/packages/perps-exes/assets/market-config-updates.yaml
@@ -572,6 +572,25 @@ markets:
 
     initial-borrow-fee-rate: 0.16
 
+  # FIXME temporary values copied from TIA_USD, do not use on mainnet
+  milkTIA_USD:
+    config:
+      trading_fee_notional_size: 0.002
+      trading_fee_counter_collateral: 0.002
+      max_leverage: 10
+      carry_leverage: 5
+      funding_rate_sensitivity: 2
+      target_utilization: 0.5
+      delta_neutrality_fee_sensitivity: 20000000
+      borrow_fee_sensitivity: 0.3
+      delta_neutrality_fee_cap: 0.015
+      delta_neutrality_fee_tax: 0.25
+      borrow_fee_rate_min_annualized: 0.08
+      liquidity_cooldown_seconds: 86400
+      exposure_margin_ratio: 0.01
+
+    initial-borrow-fee-rate: 0.16
+
   DYDX_USDC:
     config:
       carry_leverage: 15

--- a/packages/perps-exes/src/bin/perps-deploy/app.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/app.rs
@@ -63,7 +63,8 @@ pub(crate) enum PriceSourceConfig {
 #[derive(Clone, Debug)]
 pub(crate) struct OracleInfo {
     pub pyth: Option<ChainPythConfig>,
-    pub stride: Option<ChainStrideConfig>,
+    /// Fallback config if not overridden by a market
+    pub stride_fallback: Option<ChainStrideConfig>,
     pub markets: HashMap<MarketId, OracleMarketPriceFeeds>,
 }
 
@@ -71,6 +72,7 @@ pub(crate) struct OracleInfo {
 pub(crate) struct OracleMarketPriceFeeds {
     pub feeds: Vec<SpotPriceFeed>,
     pub feeds_usd: Vec<SpotPriceFeed>,
+    pub stride_contract_override: Option<Address>,
 }
 
 /// Complete app for mainnet
@@ -278,12 +280,13 @@ impl Opt {
                 OracleMarketPriceFeeds {
                     feeds: map_feeds(&price_feed_configs.feeds)?,
                     feeds_usd: map_feeds(&price_feed_configs.feeds_usd)?,
+                    stride_contract_override: price_feed_configs.stride_contract,
                 },
             );
         }
         Ok(OracleInfo {
             pyth: chain_spot_price_config.pyth.clone(),
-            stride: chain_spot_price_config.stride.clone(),
+            stride_fallback: chain_spot_price_config.stride.clone(),
             markets,
         })
     }

--- a/packages/perps-exes/src/bin/perps-deploy/faucet.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/faucet.rs
@@ -87,6 +87,7 @@ impl Faucet {
             "ryETH" => "2",
             "INJ" => "1000",
             "TIA" => "2000",
+            "milkTIA" => "2000",
             name => anyhow::bail!("Unknown collateral type: {name}"),
         }
         .parse()?;

--- a/packages/perps-exes/src/bin/perps-deploy/instantiate.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/instantiate.rs
@@ -73,6 +73,10 @@ impl App {
                         .markets
                         .get(&market_id)
                         .with_context(|| format!("No oracle market found for {market_id}"))?;
+                    let stride = match market.stride_contract_override {
+                        Some(stride) => Some(stride),
+                        None => oracle.stride_fallback.clone().map(|x| x.contract),
+                    };
 
                     let global_price_config = &self.basic.price_config;
 
@@ -81,8 +85,8 @@ impl App {
                             contract_address: pyth.contract.get_address_string().into(),
                             network: pyth.r#type,
                         }),
-                        stride: oracle.stride.as_ref().map(|stride| StrideConfigInit {
-                            contract_address: stride.contract.get_address_string().into(),
+                        stride: stride.map(|addr| StrideConfigInit {
+                            contract_address: addr.get_address_string().into(),
                         }),
                         feeds: market
                             .feeds

--- a/packages/perps-exes/src/config.rs
+++ b/packages/perps-exes/src/config.rs
@@ -123,6 +123,8 @@ pub struct MarketPriceFeedConfigs {
     pub feeds: Vec<MarketPriceFeedConfig>,
     /// feed of the collateral asset in terms of USD
     pub feeds_usd: Vec<MarketPriceFeedConfig>,
+    /// Override the Stride contract address for this market
+    pub stride_contract: Option<Address>,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]


### PR DESCRIPTION
milkTIA uses the same contracts as Stride, so we can simply reuse that code. It did introduce a new concept of market-specific Stride contract addresses. For now, I've addressed this by having a "fallback" and "override" value, but it's also an option to simply remove the fallback and be forced to provide a Stride address per-market.