### PR TITLE
PERP-2962 | catch unhandled defer errors in tests

### DIFF
--- a/packages/multi_test/src/market_wrapper.rs
+++ b/packages/multi_test/src/market_wrapper.rs
@@ -2278,7 +2278,7 @@ impl PerpsMarket {
                                 }
                                 Some(_) if reason.contains("error executing WasmMsg") => {
                                     panic!(
-                                            "validation is failing without an error message - this is a core unexpected error: {:?}",
+                                            "validation is passing but it should be failing- this is a core unexpected error: {:?}",
                                             value.status
                                         );
                                 }


### PR DESCRIPTION
This is known to be failing atm (i.e. the tests failing is exactly the thing that needs to be fixed, TDD style)

However, all the errors are of the "validation is failing without an error message" variety, none are "crank price is none in deferred exec"