### PR TITLE
PERP-2964 | liquidity error

### DIFF
--- a/contracts/market/src/state/position/close.rs
+++ b/contracts/market/src/state/position/close.rs
@@ -1,3 +1,4 @@
+use crate::state::liquidity::LiquidityUnlock;
 use crate::state::position::CLOSED_POSITIONS;
 use crate::state::{position::CLOSED_POSITION_HISTORY, *};
 use anyhow::Context;
@@ -153,7 +154,11 @@ impl State<'_> {
 
         // unlock the LP collateral
         if let Some(counter_collateral) = NonZero::new(counter_collateral) {
-            self.liquidity_unlock(ctx, counter_collateral, &settlement_price)?;
+            LiquidityUnlock {
+                amount: counter_collateral,
+                price: settlement_price,
+            }
+            .apply(self, ctx)?;
         }
 
         // send the trader's collateral to their wallet


### PR DESCRIPTION
similar approach as position updates (which this builds off: https://github.com/Levana-Protocol/levana-perps/pull/528), but for liquidity - and with a slight difference in that it re-validates (i.e. re-loads state) at apply() time.

there is one error left with `liquidity::carry_leverage_min_liquidity_update_leverage` in collateral-is-quote markets. That _might_ be due to the liquifunding difference, not sure yet, will pick that up tomorrow