### PR TITLE
Address remaining issues of PERP 2904

### DIFF
--- a/packages/perps-exes/src/bin/perps-bots/app/high_gas.rs
+++ b/packages/perps-exes/src/bin/perps-bots/app/high_gas.rs
@@ -9,7 +9,7 @@ use super::{
     gas_check::GasCheckWallet, price::price_get_update_oracles_msg, App, AppBuilder,
     CrankTriggerReason,
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_channel::RecvError;
 use axum::async_trait;
 use chrono::Duration;


### PR DESCRIPTION
Specifically alarm related to High gas bot:

* “When the channel signals there is work, but when we try taking it from the lock, there is none” It’s safe to ignore that, or maybe just print out a warning.
* “Whether we should continue receiving alerts for these ? I think the answer would be yes.” Yes except for the previous bullet.
* “Whether we should enable stickiness for some of them ?” Yes, I think so. In fact, I think for all of them.