### PR TITLE
companion: Make /healthz handler non intelligent

### DIFF
--- a/packages/perps-exes/src/bin/perps-companion/endpoints/common.rs
+++ b/packages/perps-exes/src/bin/perps-companion/endpoints/common.rs
@@ -10,7 +10,8 @@ use axum_extra::response::Css;
 use crate::app::App;
 
 use super::{
-    BuildVersionRoute, ErrorCssRoute, ErrorPage, Favicon, HealthRoute, HomeRoute, RobotRoute,
+    BuildVersionRoute, ErrorCssRoute, ErrorPage, Favicon, GrpcHealthRoute, HealthRoute, HomeRoute,
+    RobotRoute,
 };
 
 pub(crate) async fn homepage(_: HomeRoute) -> &'static str {
@@ -21,7 +22,11 @@ Not sure what you thought you'd find, but you didn't find it.
 Better luck next time."#
 }
 
-pub(crate) async fn healthz(_: HealthRoute, app: State<Arc<App>>) -> String {
+pub(crate) async fn healthz(_: HealthRoute) -> &'static str {
+    "healthy"
+}
+
+pub(crate) async fn grpc_health(_: GrpcHealthRoute, app: State<Arc<App>>) -> String {
     let mut res = "Yup, I'm alive. gRPC node health check\n\n".to_owned();
     for (chain_id, cosmos) in &app.cosmos {
         writeln!(&mut res, "{chain_id}:").unwrap();

--- a/packages/perps-exes/src/bin/perps-companion/endpoints/mod.rs
+++ b/packages/perps-exes/src/bin/perps-companion/endpoints/mod.rs
@@ -42,6 +42,10 @@ pub(crate) struct HomeRoute;
 pub(crate) struct HealthRoute;
 
 #[derive(TypedPath)]
+#[typed_path("/grpc-health")]
+pub(crate) struct GrpcHealthRoute;
+
+#[derive(TypedPath)]
 #[typed_path("/build-version")]
 pub(crate) struct BuildVersionRoute;
 
@@ -127,6 +131,7 @@ pub(crate) async fn launch(app: App) -> Result<()> {
     let router = axum::Router::new()
         .typed_get(common::homepage)
         .typed_get(common::healthz)
+        .typed_get(common::grpc_health)
         .typed_get(common::build_version)
         .typed_get(pnl::pnl_css)
         .typed_get(common::error_css)


### PR DESCRIPTION
This is used by ECS health check etc and it's best to make it as non intelligent as possible.