### PR TITLE
perp-2915 | shorten Pyth oracle update messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 [[package]]
 name = "cosmos"
 version = "0.1.0"
-source = "git+https://github.com/Levana-Protocol/levana-cosmos-rs.git?rev=a3690574e2ca75b9581838644d3d9b456fbdd453#a3690574e2ca75b9581838644d3d9b456fbdd453"
+source = "git+https://github.com/Levana-Protocol/levana-cosmos-rs.git?rev=538885332eceb0341e0163c9ad20354747295983#538885332eceb0341e0163c9ad20354747295983"
 dependencies = [
  "base64 0.21.3",
  "bech32",

--- a/packages/perps-exes/Cargo.toml
+++ b/packages/perps-exes/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
 log = "0.4.20"
-cosmos = { git = "https://github.com/Levana-Protocol/levana-cosmos-rs.git", rev = "a3690574e2ca75b9581838644d3d9b456fbdd453" }
+cosmos = { git = "https://github.com/Levana-Protocol/levana-cosmos-rs.git", rev = "538885332eceb0341e0163c9ad20354747295983" }
 cosmwasm-std = "1.1.9"
 tokio = { version = "1.34.0", default-features = false, features = [
 	"time",


### PR DESCRIPTION
Instead of ellipsizing (per Jira issue), just providing an override description.