### PR TITLE
Enable auto brotli compression for bots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +218,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
 dependencies = [
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
@@ -658,6 +674,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +854,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 [[package]]
 name = "cosmos"
 version = "0.1.0"
-source = "git+https://github.com/Levana-Protocol/levana-cosmos-rs.git?rev=538885332eceb0341e0163c9ad20354747295983#538885332eceb0341e0163c9ad20354747295983"
+source = "git+https://github.com/Levana-Protocol/levana-cosmos-rs.git?rev=2e4b1222290e1f35146714a905228fed58a04948#2e4b1222290e1f35146714a905228fed58a04948"
 dependencies = [
  "base64 0.21.3",
  "bech32",

--- a/packages/perps-exes/Cargo.toml
+++ b/packages/perps-exes/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
 log = "0.4.20"
-cosmos = { git = "https://github.com/Levana-Protocol/levana-cosmos-rs.git", rev = "538885332eceb0341e0163c9ad20354747295983" }
+cosmos = { git = "https://github.com/Levana-Protocol/levana-cosmos-rs.git", rev = "2e4b1222290e1f35146714a905228fed58a04948" }
 cosmwasm-std = "1.1.9"
 tokio = { version = "1.34.0", default-features = false, features = [
 	"time",
@@ -37,6 +37,7 @@ reqwest = { version = "0.11.22", default-features = false, features = [
 	"rustls-tls",
 	"json",
 	"gzip",
+	"brotli"
 ] }
 chrono = { version = "0.4.31", features = ["serde"] }
 axum = { version = "0.7.1", features = [ "tracing", "macros"] }


### PR DESCRIPTION
Also bump the dependencies of cosmos-rs to include compression changes from there.

The reqwest's Client is being used for these purpose in bots:

- Use pyth endpoints to fetch latest price feeds:
- RPC node height information

And testing their endpoint, *some* of them seem to be sending compressed response while some RPC nodes doesn't seem to support it.