### PR TITLE
MPA: Handle DNF computation for a market like ETH_SEI

### DIFF
--- a/packages/perps-exes/src/bin/perps-market-params/main.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use coingecko::Coin;
 use cosmos::{Address, CosmosNetwork};
+use market_param::AssetName;
 use web::axum_main;
 
 use crate::{
@@ -35,7 +36,9 @@ async fn main_inner(opt: Opt) -> Result<()> {
         }
         cli::SubCommand::Exchanges { market_id } => {
             let http_app = HttpApp::new(None, opt.cmc_key.clone());
-            let result = http_app.get_market_pair(market_id.clone()).await?;
+            let result = http_app
+                .get_market_pair(AssetName(market_id.get_base()))
+                .await?;
             let result = result.data.market_pairs;
             let exchanges = http_app.get_exchanges().await?;
             let mut unsupported_exchanges = vec![];
@@ -150,7 +153,9 @@ async fn main_inner(opt: Opt) -> Result<()> {
         cli::SubCommand::Serve { opt: serve_opt } => axum_main(serve_opt, opt).await?,
         cli::SubCommand::Market { out, market_id } => {
             let http_app = HttpApp::new(None, opt.cmc_key.clone());
-            let exchanges = http_app.get_market_pair(market_id.clone()).await?;
+            let exchanges = http_app
+                .get_market_pair(AssetName(market_id.get_base()))
+                .await?;
             tracing::info!(
                 "Total exchanges found: {} for {market_id:?}",
                 exchanges.data.market_pairs.len()

--- a/packages/perps-exes/src/bin/perps-market-params/market_param.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/market_param.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
-use shared::storage::{MarketId, MarketType};
+use shared::storage::MarketId;
 
 use crate::{
     cli::{Opt, ServeOpt},
@@ -48,34 +48,27 @@ pub(crate) async fn dnf_sensitivity(
     http_app: &HttpApp,
     market_id: &MarketId,
 ) -> anyhow::Result<f64> {
-    let quote_asset = market_id.get_quote();
-    if quote_asset == "USD" || quote_asset == "USDC" || quote_asset == "USDT" {
-        let exchanges = http_app.get_market_pair(market_id.clone()).await?;
+    let base_asset = AssetName(market_id.get_base());
+    let quote_asset = AssetName(market_id.get_quote());
+    if quote_asset.is_usd_equiv() {
+        let exchanges = http_app.get_market_pair(base_asset).await?;
         tracing::debug!(
             "Total exchanges found: {} for {market_id:?}",
             exchanges.data.market_pairs.len()
         );
         let dnf_in_usd = compute_dnf_sensitivity(exchanges.data.market_pairs)?;
-        let price = http_app.get_price_in_usd(market_id).await?;
-        let dnf_in_notional = dnf_in_usd / price;
-        return Ok(dnf_in_notional);
+        return dnf_in_usd.to_asset_amount(base_asset, http_app).await;
     }
-    let base_asset = market_id.get_base();
-    let base_market_id = MarketId::new(base_asset, "USD", MarketType::CollateralIsBase);
-    let quote_market_id = MarketId::new(quote_asset, "USD", MarketType::CollateralIsBase);
-    let base_exchanges = http_app.get_market_pair(base_market_id.clone()).await?;
-    let quote_exchanges = http_app.get_market_pair(quote_market_id.clone()).await?;
-    let base_dnf_in_quote = compute_dnf_sensitivity(base_exchanges.data.market_pairs)?;
-    let base_dnf_in_notional = {
-        let price = http_app.get_price_in_usd(&base_market_id).await?;
-        base_dnf_in_quote / price
+    let base_exchanges = http_app.get_market_pair(base_asset).await?;
+    let quote_exchanges = http_app.get_market_pair(quote_asset).await?;
+    let base_dnf_in_usd = compute_dnf_sensitivity(base_exchanges.data.market_pairs)?;
+    let quote_dnf_in_usd = compute_dnf_sensitivity(quote_exchanges.data.market_pairs)?;
+    let dnf_in_usd = if base_dnf_in_usd > quote_dnf_in_usd {
+        quote_dnf_in_usd
+    } else {
+        base_dnf_in_usd
     };
-    let quote_dnf_in_quote = compute_dnf_sensitivity(quote_exchanges.data.market_pairs)?;
-    let quote_dnf_in_notional = {
-        let price = http_app.get_price_in_usd(&quote_market_id).await?;
-        quote_dnf_in_quote / price
-    };
-    Ok(base_dnf_in_notional.min(quote_dnf_in_notional))
+    dnf_in_usd.to_asset_amount(base_asset, http_app).await
 }
 
 fn is_centralized_exchange(id: &ExchangeId) -> bool {
@@ -88,7 +81,29 @@ fn is_centralized_exchange(id: &ExchangeId) -> bool {
     }
 }
 
-fn compute_dnf_sensitivity(exchanges: Vec<CmcMarketPair>) -> anyhow::Result<f64> {
+#[derive(Clone, Copy)]
+pub(crate) struct AssetName<'a>(pub(crate) &'a str);
+impl AssetName<'_> {
+    /// Is the asset either USD or a stablecoin pinned to USD?
+    fn is_usd_equiv(&self) -> bool {
+        self.0 == "USD" || self.0 == "USDC" || self.0 == "USDT"
+    }
+}
+#[derive(PartialOrd, PartialEq)]
+struct MyUsd(f64);
+
+impl MyUsd {
+    async fn to_asset_amount(
+        &self,
+        asset: AssetName<'_>,
+        http_app: &HttpApp,
+    ) -> anyhow::Result<f64> {
+        let price = http_app.get_price_in_usd(asset).await?;
+        Ok(self.0 / price)
+    }
+}
+
+fn compute_dnf_sensitivity(exchanges: Vec<CmcMarketPair>) -> anyhow::Result<MyUsd> {
     // Algorithm: https://staff.levana.finance/new-market-checklist#dnf-sensitivity
     tracing::debug!("Total exchanges: {}", exchanges.len());
     let exchanges = exchanges.iter().filter(|exchange| {
@@ -111,7 +126,7 @@ fn compute_dnf_sensitivity(exchanges: Vec<CmcMarketPair>) -> anyhow::Result<f64>
         .depth_usd_negative_two
         .min(max_volume_exchange.depth_usd_positive_two);
     let dnf = (min_depth_liquidity / market_share) * 25.0;
-    Ok(dnf)
+    Ok(MyUsd(dnf))
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -235,7 +250,7 @@ mod tests {
             },
         ];
         let dnf = super::compute_dnf_sensitivity(exchanges).unwrap();
-        assert_eq!(dnf.round(), 268783.0, "Expected DNF");
+        assert_eq!(dnf.0.round(), 268783.0, "Expected DNF");
     }
 
     #[test]

--- a/packages/perps-exes/src/bin/perps-market-params/slack.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/slack.rs
@@ -3,11 +3,10 @@ use std::collections::HashMap;
 use anyhow::{anyhow, Context};
 use cosmos::{Address, CosmosNetwork};
 use reqwest::{Client, Url};
-use shared::storage::MarketId;
 
 use crate::{
     coingecko::{CMCExchange, CmcExchangeInfo, Coin},
-    market_param::MarketsConfig,
+    market_param::{AssetName, MarketsConfig},
 };
 
 pub(crate) struct HttpApp {
@@ -142,9 +141,8 @@ impl HttpApp {
 
     pub(crate) async fn get_market_pair(
         &self,
-        market_id: MarketId,
+        AssetName(base_asset): AssetName<'_>,
     ) -> anyhow::Result<CmcExchangeInfo> {
-        let base_asset = market_id.get_base();
         let coin: Coin = base_asset.parse()?;
         let mut start: u32 = 1;
         // https://coinmarketcap.com/api/documentation/v1/#operation/getV1ExchangeListingsLatest
@@ -193,8 +191,10 @@ impl HttpApp {
         Ok(result)
     }
 
-    pub(crate) async fn get_price_in_usd(&self, market_id: &MarketId) -> anyhow::Result<f64> {
-        let base_asset = market_id.get_base();
+    pub(crate) async fn get_price_in_usd(
+        &self,
+        AssetName(base_asset): AssetName<'_>,
+    ) -> anyhow::Result<f64> {
         let coin: Coin = base_asset.parse()?;
         // https://coinmarketcap.com/api/documentation/v1/#operation/getV2CryptocurrencyQuotesLatest
         let id = coin.cmc_id().to_string();


### PR DESCRIPTION
I thought the assert was initially created for the variable `base_market_id` and `quote_market_id`, but I didn't notice it.

I'm removing the assert and changing some code so that we get DNF computed for a market like ETH_SEI which currently trips the alert.

When the quote asset is not USD/USDC/USDT, the DNF computation formula is this:

```
DNF(BASE_QUOTE) = MIN(DNF(BASE_USD), DNF(QUOTE_USD))

where

DNF = Function which computes DNF sensitivity
MIN = Minimum function - returns minimum of two values
```

And for a market like ETH_USD/SEI_USD, the collateral is always base. But let me know if I mis-understood something wrongly.