### PR TITLE
MPA: Automatically discover new market ids

### DIFF
--- a/packages/perps-exes/src/bin/perps-market-params/cli.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/cli.rs
@@ -60,9 +60,9 @@ pub(crate) enum SubCommand {
 
 #[derive(clap::Parser, Clone, Debug)]
 pub(crate) struct ServeOpt {
-    /// Coins to track
-    #[arg(long, env = "LEVANA_MPARAM_MARKET_IDS", value_delimiter = ',')]
-    pub(crate) market_ids: Vec<MarketId>,
+    /// Market Ids to skip. By default tracks all market ids of different markets.
+    #[arg(long, env = "LEVANA_MPARAM_SKIP_MARKET_IDS", value_delimiter = ',')]
+    pub(crate) skip_market_ids: Vec<MarketId>,
     /// Slack webhook to send alert notification
     #[arg(long, env = "LEVANA_MPARAM_SLACK_WEBHOOK")]
     pub(crate) slack_webhook: reqwest::Url,


### PR DESCRIPTION
This PR enables it to automatically discovert new market ids as it is added. This coupled with the previous change will alert us if code changes are required because of the new market id that was added.