### PR TITLE
Better CSV resuming

### DIFF
--- a/packages/msg/src/contracts/market/position/closed.rs
+++ b/packages/msg/src/contracts/market/position/closed.rs
@@ -222,3 +222,23 @@ pub enum PositionOrPendingClose {
     /// The value stored here may change after actual close occurs due to pending payments.
     PendingClose(Box<ClosedPosition>),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ser_de_position_close_reason() {
+        for value in [
+            PositionCloseReason::Direct,
+            PositionCloseReason::Liquidated(LiquidationReason::Liquidated),
+            PositionCloseReason::Liquidated(LiquidationReason::MaxGains),
+            PositionCloseReason::Liquidated(LiquidationReason::StopLoss),
+            PositionCloseReason::Liquidated(LiquidationReason::TakeProfit),
+        ] {
+            let json = serde_json::to_string(&value).unwrap();
+            let parsed = serde_json::from_str(&json).unwrap();
+            assert_eq!(value, parsed);
+        }
+    }
+}


### PR DESCRIPTION
Better CSV resuming

* Fixes a bug in the deserialization of PositionCloseReason. I think this is a bad interaction between the csv crate and some of serde's more advanced features.
* Aborts processing if there's an error loading up the old file.
* Treat "no file found" as a non-error case.

I also added some tests that turned out to confirm normal serialization/deserialization is working correctly. I had originally thought that was the source of my parse error.