### PR TITLE
max_leverage update for DOGE_USDC

### DIFF
--- a/packages/perps-exes/assets/market-config-updates.toml
+++ b/packages/perps-exes/assets/market-config-updates.toml
@@ -208,7 +208,7 @@ initial-borrow-fee-rate = "0.05"
 
 [markets.DOGE_USDC.config]
 carry_leverage = "7"
-max_leverage = "50"
+max_leverage = "30"
 funding_rate_sensitivity = "1.5"
 borrow_fee_rate_min_annualized = "0.03"
 target_utilization = "0.5"


### PR DESCRIPTION
Based on the latest alert from MPA tool: 