### PR TITLE
Fix countertrade::closes_extra_positions test

### DIFF
--- a/contracts/countertrade/src/types.rs
+++ b/contracts/countertrade/src/types.rs
@@ -22,6 +22,7 @@ pub(crate) struct Totals {
 }
 
 /// Information about positions in the market contract.
+#[derive(Debug)]
 pub(crate) enum PositionsInfo {
     TooManyPositions { to_close: PositionId },
     NoPositions,

--- a/contracts/countertrade/src/work.rs
+++ b/contracts/countertrade/src/work.rs
@@ -172,7 +172,7 @@ fn desired_action(
         (long_funding, short_funding, DirectionToNotional::Long)
     } else {
         assert!(long_funding.is_negative());
-        (short_funding, long_funding, DirectionToNotional::Long)
+        (short_funding, long_funding, DirectionToNotional::Short)
     };
 
     if popular_funding >= min_funding && popular_funding <= max_funding {

--- a/packages/multi_test/tests/multi_test/countertrade.rs
+++ b/packages/multi_test/tests/multi_test/countertrade.rs
@@ -430,10 +430,10 @@ fn closes_extra_positions() {
     market
         .exec_open_position_take_profit(
             &lp,
-            "10.1",
+            "9",
             match market_type {
                 msg::prelude::MarketType::CollateralIsQuote => "5",
-                msg::prelude::MarketType::CollateralIsBase => "3",
+                msg::prelude::MarketType::CollateralIsBase => "4",
             },
             DirectionToBase::Short,
             None,
@@ -457,6 +457,9 @@ fn closes_extra_positions() {
 
         // Sends a deferred message to close the position
         market.exec_countertrade_do_work().unwrap();
+        // Will fail if we do more work again since the deferred
+        // execution would not have finished
+        market.exec_countertrade_do_work().unwrap_err();
         // Execute the deferred message
         market.exec_crank_till_finished(&lp).unwrap();
 


### PR DESCRIPTION
The test used to fail because it tried to close all the position, forced opened by the countertrade address.

Specifically this line used to fail:

// Nothing left to be done now
assert_eq!(
    market.query_countertrade_has_work().unwrap(),
    HasWorkResp::NoWork {}
);

Instead the response that came was instructing the contract to close position 5.

And looking at the contract code, that's because this condition was true:

popular_funding < min_funding

Ref:
https://github.com/Levana-Protocol/levana-perps/blob/6f7ab34bc021c666e7776635adf315b5ac92bef5/contracts/countertrade/src/work.rs#L180

In the test case, these were it's values:

popular_funding = 0.049
min_funding = 0.1

For fixing the tests, I have changed tweaked the short position's collateral and leverage to be such that the market is balanced and no new work is required.