### PR TITLE
Fix mpa partial comparison

### DIFF
--- a/packages/perps-exes/src/bin/perps-market-params/market_param.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/market_param.rs
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_min_depth_sort() {
-        let mut data = vec![
+        let mut data = [
             MinDepthLiquidity(1.0),
             MinDepthLiquidity(9.0),
             MinDepthLiquidity(4.0),


### PR DESCRIPTION
I introduced a bug which led to ord calling partial_ord and partial_ord calling ord. The test confirms that there is a stack overflow and fixes it.