### PR TITLE
perp-3856 | no more counterleverage errors

### DIFF
--- a/contracts/market/src/state/position/take_profit.rs
+++ b/contracts/market/src/state/position/take_profit.rs
@@ -1,10 +1,7 @@
 use std::ops::{Mul, Sub};
 
 use crate::prelude::*;
-use shared::{
-    compat::{calc_notional_size, TakeProfitFromCounterCollateral},
-    storage::PricePoint,
-};
+use shared::{compat::calc_notional_size, storage::PricePoint};
 
 pub(crate) struct TakeProfitToCounterCollateral<'a> {
     pub(crate) take_profit_trader: TakeProfitTrader,
@@ -18,9 +15,31 @@ pub(crate) struct TakeProfitToCounterCollateral<'a> {
 
 impl<'a> TakeProfitToCounterCollateral<'a> {
     pub(crate) fn calc(&self) -> Result<NonZero<Collateral>> {
-        let take_profit_price = self.capped_take_profit_price()?;
+        // minimum allowed counter-collateral
+        let min_counter_collateral = self
+            .price_point
+            .notional_to_collateral(self.notional_size()?.abs_unsigned())
+            .checked_div_dec(
+                self.config
+                    .max_leverage
+                    .try_into_non_negative_value()
+                    .context("Impossible negative max_leverage")?,
+            )?;
 
-        self.counter_collateral(take_profit_price)
+        // maximum allowed counter-collateral. We have a hard coded minimum
+        // leverage of 1, see position_validate_counter_leverage
+        let max_counter_collateral = self
+            .price_point
+            .notional_to_collateral(self.notional_size()?.abs_unsigned());
+
+        // user requested counter_collateral
+        let req_counter_collateral = self.counter_collateral(self.take_profit_trader)?;
+
+        let counter_collateral = req_counter_collateral
+            .raw()
+            .clamp(min_counter_collateral, max_counter_collateral);
+
+        NonZero::new(counter_collateral).context("Calculated counter_collateral is 0")
     }
 
     fn notional_size(&self) -> Result<Signed<Notional>> {
@@ -108,50 +127,6 @@ impl<'a> TakeProfitToCounterCollateral<'a> {
                 NonZero::new(Collateral::try_from_number(counter_collateral)?)
                     .context("counter_collateral is zero")
             }
-        }
-    }
-
-    // the take profit price is max of:
-    // 1. a calculated take profit price that would lock up the minimum counter collateral allowed
-    // 2. the user-requested take-profit price
-    pub fn capped_take_profit_price(&self) -> Result<TakeProfitTrader> {
-        let Self {
-            take_profit_trader,
-            market_type,
-            collateral,
-            leverage_to_base,
-            direction,
-            config,
-            price_point,
-        } = *self;
-
-        // minimum allowed counter-collateral
-        let min_counter_collateral = (price_point
-            .notional_to_collateral(self.notional_size()?.abs_unsigned())
-            .into_number()
-            / config.max_leverage)?;
-
-        // user requested counter_collateral
-        let req_counter_collateral = self.counter_collateral(take_profit_trader)?.into_number();
-
-        // counter_collateral at requested price is above min, use requested take_profit price
-        if req_counter_collateral > min_counter_collateral {
-            Ok(self.take_profit_trader)
-        }
-        // counter_collateral at requested price is below min, calculate take_profit price for min counter_collateral
-        else {
-            TakeProfitFromCounterCollateral {
-                market_type,
-                collateral,
-                counter_collateral: NonZero::new(Collateral::try_from_number(
-                    min_counter_collateral,
-                )?)
-                .context("cannot get non-zero")?,
-                leverage_to_base,
-                price_point,
-                direction,
-            }
-            .calc()
         }
     }
 }

--- a/packages/multi_test/tests/multi_test/counterleverage.rs
+++ b/packages/multi_test/tests/multi_test/counterleverage.rs
@@ -1,0 +1,43 @@
+//! PERP-808
+
+use levana_perpswap_multi_test::{market_wrapper::PerpsMarket, PerpsApp};
+use msg::prelude::*;
+
+// Before counterleverage fixes, this test case would fail for collateral-is-quote.
+#[test]
+fn counterleverage_too_low() {
+    let market = PerpsMarket::new(PerpsApp::new_cell().unwrap()).unwrap();
+    let trader = market.clone_trader(0).unwrap();
+
+    market
+        .exec_open_position_take_profit(
+            &trader,
+            "10",
+            "5",
+            DirectionToBase::Long,
+            None,
+            None,
+            TakeProfitTrader::Finite("1000000000".parse().unwrap()),
+        )
+        .unwrap();
+}
+
+// This never reproduced the bug, likely because the contracts already prevented it.
+#[test]
+fn counterleverage_too_high() {
+    let market = PerpsMarket::new(PerpsApp::new_cell().unwrap()).unwrap();
+    let trader = market.clone_trader(0).unwrap();
+
+    let (pos_id, _) = market
+        .exec_open_position_take_profit(
+            &trader,
+            "10",
+            "5",
+            DirectionToBase::Long,
+            None,
+            None,
+            TakeProfitTrader::Finite("1.0000000000001".parse().unwrap()),
+        )
+        .unwrap();
+    let _pos = market.query_position(pos_id);
+}

--- a/packages/multi_test/tests/multi_test/edge.rs
+++ b/packages/multi_test/tests/multi_test/edge.rs
@@ -307,7 +307,17 @@ fn leverage_edge() {
         None,
         None,
     );
-    assert!(response.is_err());
+    // Funky test, because it's still using the legacy max gains API,
+    // we can get an error from the max gains API. However, we do not
+    // want to accept any counterleverage errors. So: this either succeeds
+    // or specifically talks about max gains.
+    assert!(
+        response.is_ok()
+            || response
+                .unwrap_err()
+                .to_string()
+                .contains("Max gains are too large")
+    )
 }
 
 #[test]

--- a/packages/multi_test/tests/multi_test/edge_update.rs
+++ b/packages/multi_test/tests/multi_test/edge_update.rs
@@ -79,9 +79,13 @@ fn take_profit_edge() {
                             valid: Some(TakeProfitTrader::Finite(
                                 value.checked_add(partial_value.into_decimal256()).unwrap(),
                             )),
-                            invalid: Some(TakeProfitTrader::Finite(
-                                value.checked_sub(partial_value.into_decimal256()).unwrap(),
-                            )),
+                            // This check used to assert that we would receive a counterleverage
+                            // error. However, we no longer generate those, instead
+                            // correcting the countercollateral to fit the expected range.
+                            invalid: None,
+                            // invalid: Some(TakeProfitTrader::Finite(
+                            //     value.checked_sub(partial_value.into_decimal256()).unwrap(),
+                            // )),
                         },
                         Side::Max => Self {
                             side,
@@ -89,9 +93,12 @@ fn take_profit_edge() {
                             valid: Some(TakeProfitTrader::Finite(
                                 value.checked_sub(partial_value.into_decimal256()).unwrap(),
                             )),
-                            invalid: Some(TakeProfitTrader::Finite(
-                                value.checked_add(partial_value.into_decimal256()).unwrap(),
-                            )),
+                            // This check used to assert that we would receive a counterleverage
+                            // error. However, we no longer generate those, instead
+                            // correcting the countercollateral to fit the expected range.
+                            invalid: None, // invalid: Some(TakeProfitTrader::Finite(
+                                           //     value.checked_add(partial_value.into_decimal256()).unwrap(),
+                                           // )),
                         },
                     }
                 }
@@ -104,9 +111,9 @@ fn take_profit_edge() {
                 assert!(response.is_ok());
             }
             if let Some(invalid) = self.invalid {
-                let response =
-                    market.exec_update_position_take_profit(trader, position_id, invalid);
-                assert!(response.is_err());
+                market
+                    .exec_update_position_take_profit(trader, position_id, invalid)
+                    .unwrap_err();
             }
         }
     }

--- a/packages/multi_test/tests/multi_test/main.rs
+++ b/packages/multi_test/tests/multi_test/main.rs
@@ -1,3 +1,4 @@
+mod counterleverage;
 mod countertrade;
 mod crank_fee;
 mod crank_price;

--- a/packages/shared/src/number/types.rs
+++ b/packages/shared/src/number/types.rs
@@ -655,7 +655,15 @@ impl Collateral {
         self.0
             .checked_mul(rhs)
             .map(Collateral)
-            .with_context(|| format!("Collateral::checked_mul_ratio failed on {self} * {rhs}"))
+            .with_context(|| format!("Collateral::checked_mul_dec failed on {self} * {rhs}"))
+    }
+
+    /// Divide by the given [Decimal256]
+    pub fn checked_div_dec(self, rhs: Decimal256) -> Result<Collateral> {
+        self.0
+            .checked_div(rhs)
+            .map(Collateral)
+            .with_context(|| format!("Collateral::checked_div_dec failed on {self} * {rhs}"))
     }
 
     /// Divide by a non-zero decimal.


### PR DESCRIPTION
Previously, the code would take the take profit price, calculate a _modified_ take profit price if the value would produce too high a counter leverage, and then use that for counter leverage calculations. This introduces two changes:

1. No need to hop through take profit price. We can simply clamp the counter leverage
2. Instead of only preventing too high a counterleverage, we also prevent too low

Point (2) means that users will end up borrowing more funds than they need in some cases, which is exactly the behavior we want to create.