### PR TITLE
CI: Add check for cache-docker-images task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Rustfmt
         run: just cargo-fmt-check
       - name: Cache docker images
+        if: ${{ (steps.contracts.outputs.contracts == 'true' || github.ref == 'refs/heads/main') }}
         run: just cache-docker-images
       - name: Typescript check
         run: just typescript-check


### PR DESCRIPTION
This should save 20 seconds in the build.

Motivation: If the contracts are not built, then there is no need for the docker images to be cached beforehand since we are not going to use the images.