### PR TITLE
perps-deploy: Countertrade stats - Update popular funding output

### DIFF
--- a/packages/perps-exes/src/bin/perps-deploy/cli.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/cli.rs
@@ -75,11 +75,6 @@ pub(crate) enum TestnetSub {
         #[clap(flatten)]
         inner: crate::testnet::sync_config::SyncConfigOpts,
     },
-    /// CounterTrade utility to fill collateral for markets
-    CounterTrade {
-        #[clap(subcommand)]
-        inner: crate::testnet::countertrade::CounterTradeSub,
-    },
 }
 
 #[derive(clap::Parser)]

--- a/packages/perps-exes/src/bin/perps-deploy/main.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/main.rs
@@ -47,7 +47,6 @@ async fn main_inner() -> anyhow::Result<()> {
             TestnetSub::AddMarket { inner } => inner.go(opt).await?,
             TestnetSub::UpdateMarketConfigs { inner } => inner.go(opt).await?,
             TestnetSub::SyncConfig { inner } => inner.go(opt).await?,
-            TestnetSub::CounterTrade { inner } => inner.go(opt).await?,
         },
         Subcommand::Mainnet { inner } => mainnet::go(opt, inner).await?,
         Subcommand::Util { inner } => inner.go(opt).await?,

--- a/packages/perps-exes/src/bin/perps-deploy/testnet/mod.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/testnet/mod.rs
@@ -1,5 +1,4 @@
 pub(crate) mod add_market;
-pub(crate) mod countertrade;
 pub(crate) mod deposit;
 pub(crate) mod disable;
 pub(crate) mod enable_market;

--- a/packages/perps-exes/src/bin/perps-deploy/util_cmd.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/util_cmd.rs
@@ -1,3 +1,4 @@
+mod countertrade;
 mod deferred_exec;
 mod gov_distribute;
 mod list_contracts;
@@ -107,6 +108,11 @@ enum Sub {
         #[clap(flatten)]
         inner: gov_distribute::GovDistributeOpt,
     },
+    /// Countertrade Utilities
+    CounterTrade {
+        #[clap(subcommand)]
+        inner: countertrade::CounterTradeSub,
+    },
 }
 
 impl UtilOpt {
@@ -124,6 +130,7 @@ impl UtilOpt {
             Sub::TopTraders { inner } => inner.go(opt).await,
             Sub::TradingIncentivesCsv { inner } => inner.go(opt).await,
             Sub::GovDistribute { inner } => inner.go(opt).await,
+            Sub::CounterTrade { inner } => inner.go(opt).await,
         }
     }
 }


### PR DESCRIPTION
I wonder if it's possible to move it to top level since it's going to be applicable for both tesetnet and mainnet from now.