### PR TITLE
MPA: Using both positive and negative 2% depth_usd for calculation

### DIFF
--- a/packages/perps-exes/src/bin/perps-market-params/justfile
+++ b/packages/perps-exes/src/bin/perps-market-params/justfile
@@ -16,7 +16,7 @@ compute-dnf:
 
 # Current market dnf
 current-dnf:
-	cargo run --bin perps-market-params current-market-dnf --market-id BNB_USDC
+	cargo run --bin perps-market-params current-market-dnf --market-id stDYDX_USDC
 
 # Serve web app
 serve:


### PR DESCRIPTION
Also switch to using volume_24h usd parameter for a market like MAGA_USDC as that seems be giving a more reasonable value for it. Without it, the max_leverage seems to be coming much higher than expected.

Note that there is some other pending work on MPA and a Jira issue is tracking it: https://phobosfinance.atlassian.net/jira/software/c/projects/PERP/issues/PERP-399 I'm hoping to get back to it soon once I finish some other tasks.