### PR TITLE
countertrade contract: Close position

### DIFF
--- a/contracts/countertrade/src/work.rs
+++ b/contracts/countertrade/src/work.rs
@@ -716,27 +716,12 @@ fn compute_delta_notional(
                 collateral,
                 pos_id,
                 crank_fee,
-            } => match countertrade_position {
-                Some(countertrade_position) => {
-                    if collateral >= countertrade_position.active_collateral.raw() {
-                        WorkDescription::ClosePosition {
-                            pos_id: countertrade_position.id,
-                        }
-                    } else {
-                        WorkDescription::UpdatePositionRemoveCollateralImpactSize {
-                            pos_id,
-                            amount: NonZero::new(collateral)
-                                .context("remove_collateral is zero")?,
-                            crank_fee,
-                        }
-                    }
-                }
-                None => WorkDescription::UpdatePositionRemoveCollateralImpactSize {
-                    pos_id,
-                    amount: NonZero::new(collateral).context("remove_collateral is zero")?,
-                    crank_fee,
-                },
+            } => WorkDescription::UpdatePositionRemoveCollateralImpactSize {
+                pos_id,
+                amount: NonZero::new(collateral).context("remove_collateral is zero")?,
+                crank_fee,
             },
+            Capital::Close { pos_id } => WorkDescription::ClosePosition { pos_id },
         },
         None => return Ok(None),
     };
@@ -756,6 +741,9 @@ enum Capital {
         collateral: Collateral,
         pos_id: PositionId,
         crank_fee: Collateral,
+    },
+    Close {
+        pos_id: PositionId,
     },
 }
 
@@ -822,6 +810,10 @@ fn optimize_capital_efficiency(
                     // to be reduce, it's not worth performing this
                     // action
                     None
+                } else if max_deduct >= countertrade_position.active_collateral.raw() {
+                    Some(Capital::Close {
+                        pos_id: countertrade_position.id,
+                    })
                 } else {
                     Some(Capital::RemoveCollateral {
                         collateral: max_deduct,


### PR DESCRIPTION
Close position when removing collateral can cause active collateral of the countertrade position to become negative.

Should fix this alert: https://fpcomplete.slack.com/archives/C04UX1B5E1E/p1726515024242689