### PR TITLE
perp-4165 | handle the missing final closed position bug

### DIFF
--- a/contracts/market/src/state/position.rs
+++ b/contracts/market/src/state/position.rs
@@ -173,10 +173,10 @@ impl State<'_> {
         let (min, max) = match (cursor, order) {
             (None, _) => (None, None),
             (Some(cursor), OrderInMessage::Ascending) => {
-                (Some(Bound::inclusive((cursor.time, cursor.position))), None)
+                (Some(Bound::exclusive((cursor.time, cursor.position))), None)
             }
             (Some(cursor), OrderInMessage::Descending) => {
-                (None, Some(Bound::inclusive((cursor.time, cursor.position))))
+                (None, Some(Bound::exclusive((cursor.time, cursor.position))))
             }
         };
 
@@ -194,6 +194,7 @@ impl State<'_> {
                 }
                 Some(res) => {
                     let (key, pos) = res?;
+                    positions.push(pos);
                     // continuations only exist when we reach a limit and break early
                     if positions.len() == limit {
                         // slight optimization, to avoid needless pagination
@@ -206,7 +207,6 @@ impl State<'_> {
                             break None;
                         }
                     }
-                    positions.push(pos);
                 }
             }
         };


### PR DESCRIPTION
This is especially noticeable when using a limit of 1, but could in theory happen elsewhere also. I changed the logic to use exclusive bounds and to make the cursor represent the _next_ position we'll see, which is more in line with how other parts of the code do enumerations. There are other ways to skin this, but this seems like the most direct. Downside: slight change in what users will receive. We should confirm through manual testing that all positions still appear in the frontend with this change.