### PR TITLE
Ensure sufficient collateral remaining while removing.

### DIFF
--- a/contracts/countertrade/src/work.rs
+++ b/contracts/countertrade/src/work.rs
@@ -817,10 +817,11 @@ fn optimize_capital_efficiency(
                 // We should reduce collateral
                 let estimated_crank_fee = estimate_crank_fee(state, market_info, price)?;
                 let collateral = diff.abs_unsigned();
-                let countertrade_final_deposit_collateral = countertrade_position
-                    .deposit_collateral
+                let countertrade_final_active_collateral = countertrade_position
+                    .active_collateral
+                    .into_signed()
                     .checked_sub(collateral.into_signed())?;
-                let max_deduct = if countertrade_final_deposit_collateral
+                let max_deduct = if countertrade_final_active_collateral
                     >= min_deposit_collateral.into_signed()
                 {
                     collateral


### PR DESCRIPTION
The code previously used deposit collateral for this calculation. However, looking at the market contract, we use the active collateral there. I'm not convinced _either_ makes a lot of sense, but then again I'm not sure the entire concept of minimum deposit makes much sense.

Regardless, I believe this fixes the discrepancy between the market and countertrade contracts.