### PR TITLE
tests: Optimize a test taking 25 seconds (so totally 50 seconds)

### DIFF
--- a/packages/multi_test/tests/multi_test/position/misc.rs
+++ b/packages/multi_test/tests/multi_test/position/misc.rs
@@ -89,7 +89,7 @@ fn position_misc_short_1() {
         })
         .unwrap();
 
-    for i in 0..100 {
+    for i in 0..10 {
         let (pos_id, _) = market
             .exec_open_position(
                 &trader,


### PR DESCRIPTION
This seemed to be the easiest to optimize since I don't think opening 10 position or 100 positions matters.

That being said, I wonder if it can be even reduced further to something like 2 instead of 10 here.