### PR TITLE
contracts: Remove perp_bail macro

### DIFF
--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -98,12 +98,11 @@ pub fn instantiate(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> Result<Response> {
     if msg.requires_owner() && Some(info.sender.clone()) != get_owner(deps.storage)? {
-        perp_bail!(
-            ErrorId::Auth,
+        let error = PerpError::auth(
             ErrorDomain::Default,
-            "{} is not the auth contract owner",
-            info.sender
-        )
+            format!("{} is not the auth contract owner", info.sender),
+        );
+        bail!(error)
     }
 
     execute_msg(deps, env, Some(info), msg)
@@ -112,11 +111,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> R
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn sudo(deps: DepsMut, env: Env, msg: ExecuteMsg) -> Result<Response> {
     if !msg.requires_owner() || get_owner(deps.storage)?.is_some() {
-        perp_bail!(
-            ErrorId::Auth,
+        bail!(PerpError::auth(
             ErrorDomain::Default,
-            "Sudo entrypoint is only available for the factory which does not have owner",
-        )
+            "Sudo entrypoint is only available for the factory which does not have owner"
+        ))
     }
 
     execute_msg(deps, env, None, msg)

--- a/contracts/factory/src/state/liquidity_token.rs
+++ b/contracts/factory/src/state/liquidity_token.rs
@@ -47,12 +47,11 @@ pub(crate) fn save_liquidity_token_addr(
         .may_load(store, market_id.clone())?
         .is_some()
     {
-        perp_bail!(
+        bail!(PerpError::new(
             ErrorId::AddressAlreadyExists,
             ErrorDomain::Factory,
-            "liquidity token address for market {} already exists",
-            market_id
-        );
+            "liquidity token address for market {} already exists"
+        ))
     }
 
     addrs_map(kind).save(store, market_id.clone(), addr)?;

--- a/contracts/factory/src/state/shutdown.rs
+++ b/contracts/factory/src/state/shutdown.rs
@@ -42,12 +42,9 @@ pub(crate) fn shutdown(
     } else if wind_down == info.sender {
         ShutdownWallet::WindDown
     } else {
-        perp_bail!(
-            ErrorId::Auth,
-            ErrorDomain::Factory,
-            "Shutdown actions can only be called by kill switch ({kill_switch}) and wind down ({wind_down}) wallets, executed by {}",
-            info.sender
-        );
+        let msg = format!("Shutdown actions can only be called by kill switch ({kill_switch}) and wind down ({wind_down}) wallets, executed by {}",
+            info.sender);
+        bail!(PerpError::auth(ErrorDomain::Factory, msg))
     };
 
     // Avoid interleaving reads and writes, proactively do all the lookups

--- a/contracts/faucet/src/contract.rs
+++ b/contracts/faucet/src/contract.rs
@@ -59,12 +59,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> R
 
     fn validate_owner(store: &dyn Storage, info: &MessageInfo) -> Result<()> {
         if !is_admin(store, &info.sender) {
-            perp_bail!(
-                ErrorId::Auth,
+            bail!(PerpError::auth(
                 ErrorDomain::Faucet,
-                "{} is not owner",
-                info.sender
-            );
+                format!("{} is not owner", info.sender)
+            ))
         }
 
         Ok(())

--- a/contracts/faucet/src/state/faucet.rs
+++ b/contracts/faucet/src/state/faucet.rs
@@ -173,11 +173,11 @@ impl State<'_> {
         };
 
         if amount < Number::ZERO {
-            perp_bail!(
+            bail!(PerpError::new(
                 ErrorId::InvalidAmount,
                 ErrorDomain::Faucet,
                 "amount must be greater than zero!"
-            );
+            ))
         }
 
         match &asset {

--- a/contracts/market/src/state/liquidity.rs
+++ b/contracts/market/src/state/liquidity.rs
@@ -661,11 +661,12 @@ impl State<'_> {
         let total_yield = addr_stats.total_yield()?;
         let total_yield = match NonZero::new(total_yield) {
             Some(total_yield) => total_yield,
-            None => perp_bail!(
-                ErrorId::NoYieldToClaim,
-                ErrorDomain::Market,
-                "liquidity_claim_yield: total yield is 0"
-            ),
+            None => {
+                bail!(PerpError::market(
+                    ErrorId::NoYieldToClaim,
+                    "liquidity_claim_yield: total yield is 0"
+                ))
+            }
         };
 
         addr_stats.lp_accrued_yield = Collateral::zero();

--- a/contracts/market/src/state/liquidity/cw20.rs
+++ b/contracts/market/src/state/liquidity/cw20.rs
@@ -129,11 +129,11 @@ impl State<'_> {
             QueryMsg::MarketingInfo {} => MarketingInfoResponse::default().query_result(),
 
             QueryMsg::Version {} => {
-                perp_bail!(
+                bail!(PerpError::new(
                     ErrorId::InvalidLiquidityTokenMsg,
                     ErrorDomain::LiquidityToken,
                     "unreachable (version msg)"
-                );
+                ))
             }
         }
     }

--- a/contracts/market/src/state/position/update.rs
+++ b/contracts/market/src/state/position/update.rs
@@ -113,11 +113,10 @@ impl State<'_> {
                     .map_err(|_| ())
             );
 
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::DirectionToBaseFlipped,
-                ErrorDomain::Market,
                 "Position updates caused the direction to base to flip"
-            )
+            ))
         }
 
         let leverage_delta = (new_leverage.into_number() - old_leverage.into_number())?;
@@ -341,11 +340,10 @@ impl UpdatePositionSizeExec {
             .into_number()
             .approx_gt_strict(Number::ZERO)?
         {
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::PositionUpdate,
-                ErrorDomain::Market,
                 "Active collateral cannot be negative!"
-            );
+            ))
         }
 
         let scale_factor = ((pos.active_collateral.into_number()
@@ -519,11 +517,10 @@ impl UpdatePositionLeverageExec {
         let original_pos = pos.clone();
 
         if notional_size.into_number().approx_eq(Number::ZERO)? {
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::PositionUpdate,
-                ErrorDomain::Market,
                 "Notional size cannot be zero!"
-            );
+            ))
         }
 
         // Update

--- a/contracts/market/src/state/spot_price.rs
+++ b/contracts/market/src/state/spot_price.rs
@@ -599,16 +599,16 @@ impl State<'_> {
                                             .checked_sub(resp.update_time)
                                     {
                                         if time_diff > (*age_tolerance_seconds).into() {
-                                            perp_bail!(
+                                            let error_msg = format!("Current price is not available. Price denom: {}, Current block time: {}, price publish time: {}, diff: {}, age_tolerance: {}", denom
+                                                , current_block_time_seconds
+                                                , resp.update_time
+                                                , time_diff
+                                                , age_tolerance_seconds);
+                                            bail!(PerpError::new(
                                                 ErrorId::PriceTooOld,
                                                 ErrorDomain::Stride,
-                                                "Current price is not available. Price denom: {}, Current block time: {}, price publish time: {}, diff: {}, age_tolerance: {}",
-                                                denom,
-                                                current_block_time_seconds,
-                                                resp.update_time,
-                                                time_diff,
-                                                age_tolerance_seconds
-                                            )
+                                                error_msg
+                                            ))
                                         }
                                     }
                                 }
@@ -654,16 +654,17 @@ impl State<'_> {
                                     if time_diff
                                         > Duration::from_seconds((*age_tolerance_seconds).into())
                                     {
-                                        perp_bail!(
-                                            ErrorId::PriceTooOld,
-                                            ErrorDomain::SimpleOracle,
-                                            "Current price is not available on simple oracle. Price contract: {}, Current block time: {}, price publish time: {}, diff: {:?}, age_tolerance: {}",
+                                        let error_msg = format!("Current price is not available on simple oracle. Price contract: {}, Current block time: {}, price publish time: {}, diff: {:?}, age_tolerance: {}",
                                             contract,
                                             current_block_time_seconds,
                                             publish_time,
                                             time_diff,
-                                            age_tolerance_seconds
-                                        )
+                                            age_tolerance_seconds);
+                                        bail!(PerpError::new(
+                                            ErrorId::PriceTooOld,
+                                            ErrorDomain::SimpleOracle,
+                                            error_msg
+                                        ))
                                     }
                                 }
 

--- a/contracts/market/src/state/token.rs
+++ b/contracts/market/src/state/token.rs
@@ -64,10 +64,14 @@ impl State<'_> {
 
                 match token {
                     Token::Cw20 { .. } => {
-                        perp_bail!(ErrorId::Cw20Funds, ErrorDomain::Wallet, "{}", msg);
+                        bail!(PerpError::new(ErrorId::Cw20Funds, ErrorDomain::Wallet, msg))
                     }
                     Token::Native { .. } => {
-                        perp_bail!(ErrorId::NativeFunds, ErrorDomain::Wallet, "{}", msg);
+                        bail!(PerpError::new(
+                            ErrorId::NativeFunds,
+                            ErrorDomain::Wallet,
+                            msg
+                        ))
                     }
                 }
             }

--- a/packages/perpswap/src/contracts/cw20/entry.rs
+++ b/packages/perpswap/src/contracts/cw20/entry.rs
@@ -25,32 +25,32 @@ impl InstantiateMsg {
     pub fn validate(&self) -> anyhow::Result<()> {
         // Check name, symbol, decimals
         if !self.has_valid_name() {
-            perp_bail!(
+            bail!(PerpError::new(
                 ErrorId::MsgValidation,
                 ErrorDomain::Cw20,
                 "Name is not in the expected format (3-50 UTF-8 bytes)"
-            );
+            ))
         }
         if !self.has_valid_symbol() {
-            perp_bail!(
+            bail!(PerpError::new(
                 ErrorId::MsgValidation,
                 ErrorDomain::Cw20,
                 "Ticker symbol is not in expected format [a-zA-Z\\-]{{3,12}}"
-            );
+            ))
         }
         if self.decimals > 18 {
-            perp_bail!(
+            bail!(PerpError::new(
                 ErrorId::MsgValidation,
                 ErrorDomain::Cw20,
                 "Decimals must not exceed 18"
-            );
+            ))
         }
         if !self.has_valid_balances() {
-            perp_bail!(
+            bail!(PerpError::new(
                 ErrorId::MsgValidation,
                 ErrorDomain::Cw20,
                 "duplicate account balances"
-            );
+            ))
         }
         Ok(())
     }

--- a/packages/perpswap/src/contracts/market/config.rs
+++ b/packages/perpswap/src/contracts/market/config.rs
@@ -213,132 +213,117 @@ impl Config {
         // note - crank_execs_after_push and mute_events are inherently always valid
 
         if self.trading_fee_notional_size >= "0.0999".parse().unwrap() {
-            perp_bail!(ErrorId::Config, ErrorDomain::Market, "trading_fee_notional_size must be in the range 0 to 0.0999 inclusive ({} is invalid)", self.trading_fee_notional_size );
+            let error_msg = format!("trading_fee_notional_size must be in the range 0 to 0.0999 inclusive ({} is invalid)", self.trading_fee_notional_size);
+            bail!(PerpError::market(ErrorId::Config, error_msg))
         }
 
         if self.trading_fee_counter_collateral >= "0.0999".parse().unwrap() {
-            perp_bail!(ErrorId::Config, ErrorDomain::Market, "trading_fee_counter_collateral must be in the range 0 to 0.0999 inclusive ({} is invalid)", self.trading_fee_counter_collateral );
+            let error_msg = format!("trading_fee_counter_collateral must be in the range 0 to 0.0999 inclusive ({} is invalid)", self.trading_fee_counter_collateral);
+            bail!(PerpError::market(ErrorId::Config, error_msg))
         }
 
         if self.crank_execs == 0 {
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::Config,
-                ErrorDomain::Market,
                 "crank_execs_per_batch must be greater than zero"
-            );
+            ))
         }
 
         if self.max_leverage <= Number::ONE {
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::Config,
-                ErrorDomain::Market,
-                "max_leverage must be greater than one ({} is invalid)",
-                self.max_leverage
-            );
+                format!(
+                    "max_leverage must be greater than one ({} is invalid)",
+                    self.max_leverage
+                )
+            ))
         }
 
         if self.carry_leverage <= Decimal256::one() {
-            perp_bail!(
+            bail!(PerpError::market(
                 ErrorId::Config,
-                ErrorDomain::Market,
-                "carry_leverage must be greater than one ({} is invalid)",
-                self.carry_leverage
-            );
+                format!(
+                    "carry_leverage must be greater than one ({} is invalid)",
+                    self.carry_leverage
+                )
+            ))
         }
 
         if (self.carry_leverage.into_number() + Number::ONE)? > self.max_leverage {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
-                "carry_leverage must be at least one less than max_leverage ({} is invalid, max_leverage is {})",
+            let msg = format!("carry_leverage must be at least one less than max_leverage ({} is invalid, max_leverage is {})",
                 self.carry_leverage,
-                self.max_leverage
-            );
+                self.max_leverage);
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.borrow_fee_rate_max_annualized < self.borrow_fee_rate_min_annualized {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
-                "borrow_fee_rate_min_annualized ({}) must be less than borrow_fee_rate_max_annualized ({})",
+            let msg = format!("borrow_fee_rate_min_annualized ({}) must be less than borrow_fee_rate_max_annualized ({})",
                 self.borrow_fee_rate_min_annualized,
-                self.borrow_fee_rate_max_annualized
-            );
+                self.borrow_fee_rate_max_annualized);
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.protocol_tax >= Decimal256::one() {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "protocol_tax must be less than or equal to 1 ({} is invalid)",
                 self.protocol_tax
             );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.unstake_period_seconds == 0 {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "unstake period must be greater than 0 ({} is invalid)",
                 self.unstake_period_seconds
             );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if Number::from(self.target_utilization) >= Number::ONE {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "Target utilization ratio must be between 0 and 1 exclusive ({} is invalid)",
                 self.target_utilization
             );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if Number::from(self.min_xlp_rewards_multiplier) < Number::ONE {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "Min xLP rewards multiplier must be at least 1 ({} is invalid)",
                 self.max_xlp_rewards_multiplier
-            )
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.max_xlp_rewards_multiplier < self.min_xlp_rewards_multiplier {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "Max xLP rewards multiplier ({}) must be greater than or equal to the min ({})",
-                self.max_xlp_rewards_multiplier,
-                self.min_xlp_rewards_multiplier
-            )
+                self.max_xlp_rewards_multiplier, self.min_xlp_rewards_multiplier
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.crank_fee_charged < self.crank_fee_reward {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "Crank fee charged ({}) must be greater than or equal to the crank fee reward ({})",
-                self.crank_fee_charged,
-                self.crank_fee_reward
-            )
+                self.crank_fee_charged, self.crank_fee_reward
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.delta_neutrality_fee_tax > Decimal256::one() {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
+            let msg = format!(
                 "Delta neutrality fee tax ({}) must be less than or equal to 1",
                 self.delta_neutrality_fee_tax
-            )
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         if self.liquifunding_delay_fuzz_seconds >= self.liquifunding_delay_seconds {
-            perp_bail!(
-                ErrorId::Config,
-                ErrorDomain::Market,
-                "Liquifunding delay fuzz ({}) must be less than or equal to the liquifunding delay ({})",
+            let msg = format!("Liquifunding delay fuzz ({}) must be less than or equal to the liquifunding delay ({})",
                 self.liquifunding_delay_fuzz_seconds,
-                self.liquifunding_delay_seconds,
-            )
+                self.liquifunding_delay_seconds);
+            bail!(PerpError::market(ErrorId::Config, msg))
         }
 
         Ok(())

--- a/packages/perpswap/src/error.rs
+++ b/packages/perpswap/src/error.rs
@@ -171,19 +171,6 @@ macro_rules! perp_ensure {
     }};
 }
 
-/// Return early with the given perp error
-#[macro_export]
-macro_rules! perp_bail {
-    ($id:expr, $domain:expr, $($t:tt)*) => {{
-        return Err(anyhow::Error::new($crate::error::PerpError {
-            id: $id,
-            domain: $domain,
-            description: format!($($t)*),
-            data: None::<()>,
-        }));
-    }};
-}
-
 /// Like [perp_bail] but takes extra optional data
 #[macro_export]
 macro_rules! perp_bail_data {
@@ -218,6 +205,36 @@ impl<T: Serialize> fmt::Debug for PerpError<T> {
 }
 
 impl PerpError {
+    /// Create a new [Self] but with empty data.
+    pub fn new(id: ErrorId, domain: ErrorDomain, desc: impl Into<String>) -> Self {
+        PerpError {
+            id,
+            domain,
+            description: desc.into(),
+            data: None,
+        }
+    }
+
+    /// Create a new auth error but with empty data.
+    pub fn auth(domain: ErrorDomain, desc: impl Into<String>) -> Self {
+        PerpError {
+            id: ErrorId::Auth,
+            domain,
+            description: desc.into(),
+            data: None,
+        }
+    }
+
+    /// Create a new [Self] for market contract, but with no data.
+    pub fn market(id: ErrorId, desc: impl Into<String>) -> Self {
+        PerpError {
+            id,
+            domain: ErrorDomain::Market,
+            description: desc.into(),
+            data: None,
+        }
+    }
+
     /// Include error information into an event
     pub fn mixin_event(&self, evt: Event) -> Event {
         // these unwraps are okay, just a shorthand helper to get the enum variants as a string

--- a/packages/perpswap/src/prelude.rs
+++ b/packages/perpswap/src/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::{
     storage::{external_map_has, load_external_item, load_external_map},
 };
 pub use crate::{
-    error::*, perp_anyhow, perp_anyhow_data, perp_bail, perp_bail_data, perp_ensure, perp_error,
+    error::*, perp_anyhow, perp_anyhow_data, perp_bail_data, perp_ensure, perp_error,
     perp_error_data,
 };
 


### PR DESCRIPTION
I believe this port is a totally backward compatible change, the only difference is that we are using `bail` macro from anyhow instead of our custom made macro.

perp_bail macro did this:

```
return Err(anyhow::Error::new(PerpError {....}))
```

Now we are doing this instead:

```
bail!(PerpError {...})
```

The bail would expand to `return Err(anyhow!(PerpError {...}))` which would inturn expand to `return Err(anyhow::Error(PerErrpr {...}))`