### PR TITLE
contracts: Remove perp_error macro usage

### DIFF
--- a/contracts/market/src/state/spot_price.rs
+++ b/contracts/market/src/state/spot_price.rs
@@ -228,11 +228,10 @@ impl State<'_> {
         timestamp: Timestamp,
     ) -> Result<PricePoint> {
         self.spot_price_inner_opt(store, timestamp)?.ok_or_else(|| {
-            perp_error!(
+            PerpError::new(
                 ErrorId::PriceNotFound,
                 ErrorDomain::SpotPrice,
-                "there is no spot price for timestamp {}",
-                timestamp
+                format!("there is no spot price for timestamp {timestamp}"),
             )
             .into()
         })
@@ -522,16 +521,13 @@ impl State<'_> {
                                             (*age_tolerance_seconds).into(),
                                         )
                                         .ok_or_else(|| {
-                                            perp_error!(
-                                                ErrorId::PriceTooOld,
-                                                ErrorDomain::Pyth,
-                                                "Current price is not available. Price id: {}, Current block time: {}, price publish time: {}, diff: {}, age_tolerance: {}",
+                                            let error_msg = format!("Current price is not available. Price id: {}, Current block time: {}, price publish time: {}, diff: {}, age_tolerance: {}",
                                                 id,
                                                 current_block_time_seconds,
                                                 price_feed.get_price_unchecked().publish_time,
                                                 (price_feed.get_price_unchecked().publish_time - current_block_time_seconds).abs(),
-                                                age_tolerance_seconds
-                                            )
+                                                age_tolerance_seconds);
+                                            PerpError::new(ErrorId::PriceTooOld, ErrorDomain::Pyth, error_msg)
                                         })?
                                 } else {
                                     price_feed.get_price_unchecked()

--- a/packages/perpswap/src/contracts/market/entry.rs
+++ b/packages/perpswap/src/contracts/market/entry.rs
@@ -1456,12 +1456,10 @@ impl FromStr for StopLoss {
             REMOVE_STR => Ok(StopLoss::Remove),
             _ => match src.parse() {
                 Ok(number) => Ok(StopLoss::Price(number)),
-                Err(err) => Err(perp_error!(
+                Err(err) => Err(PerpError::new(
                     ErrorId::Conversion,
                     ErrorDomain::Default,
-                    "error converting {} to StopLoss , {}",
-                    src,
-                    err
+                    format!("error converting {} to StopLoss , {}", src, err),
                 )),
             },
         }

--- a/packages/perpswap/src/error.rs
+++ b/packages/perpswap/src/error.rs
@@ -104,19 +104,6 @@ pub enum ErrorDomain {
     SimpleOracle,
 }
 
-/// Generate a [PerpError] value
-#[macro_export]
-macro_rules! perp_error {
-    ($id:expr, $domain:expr, $($t:tt)*) => {{
-        $crate::error::PerpError {
-            id: $id,
-            domain: $domain,
-            description: format!($($t)*),
-            data: None::<()>,
-        }
-    }};
-}
-
 /// Generate a [PerpError] value with additional optional data
 #[macro_export]
 macro_rules! perp_error_data {

--- a/packages/perpswap/src/max_gains.rs
+++ b/packages/perpswap/src/max_gains.rs
@@ -41,12 +41,10 @@ impl FromStr for MaxGainsInQuote {
             POS_INF_STR => Ok(MaxGainsInQuote::PosInfinity),
             _ => match src.parse() {
                 Ok(number) => Ok(MaxGainsInQuote::Finite(number)),
-                Err(err) => Err(perp_error!(
+                Err(err) => Err(PerpError::new(
                     ErrorId::Conversion,
                     ErrorDomain::Default,
-                    "error converting {} to MaxGainsInQuote, {}",
-                    src,
-                    err
+                    format!("error converting {} to MaxGainsInQuote, {}", src, err),
                 )),
             },
         }

--- a/packages/perpswap/src/prelude.rs
+++ b/packages/perpswap/src/prelude.rs
@@ -21,9 +21,7 @@ pub use crate::{
     auth::*,
     storage::{external_map_has, load_external_item, load_external_map},
 };
-pub use crate::{
-    error::*, perp_anyhow, perp_anyhow_data, perp_ensure, perp_error, perp_error_data,
-};
+pub use crate::{error::*, perp_anyhow, perp_anyhow_data, perp_ensure, perp_error_data};
 
 pub use anyhow::{anyhow, bail, Context, Result};
 pub use cosmwasm_schema::cw_serde;

--- a/packages/perpswap/src/price.rs
+++ b/packages/perpswap/src/price.rs
@@ -540,12 +540,10 @@ impl FromStr for TakeProfitTrader {
             POS_INF_STR => Ok(TakeProfitTrader::PosInfinity),
             _ => match src.parse() {
                 Ok(number) => Ok(TakeProfitTrader::Finite(number)),
-                Err(err) => Err(perp_error!(
+                Err(err) => Err(PerpError::new(
                     ErrorId::Conversion,
                     ErrorDomain::Default,
-                    "error converting {} to TakeProfitPrice , {}",
-                    src,
-                    err
+                    format!("error converting {} to TakeProfitPrice , {}", src, err),
                 )),
             },
         }

--- a/packages/perpswap/src/time.rs
+++ b/packages/perpswap/src/time.rs
@@ -1,9 +1,6 @@
 //! Types to represent timestamps and durations.
+use crate::error::{ErrorDomain, ErrorId, PerpError};
 use crate::prelude::*;
-use crate::{
-    error::{ErrorDomain, ErrorId, PerpError},
-    perp_error,
-};
 use anyhow::Result;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
@@ -270,12 +267,10 @@ impl FromStr for Timestamp {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let err = |msg: &str| -> PerpError {
-            perp_error!(
+            PerpError::new(
                 ErrorId::Conversion,
                 ErrorDomain::Default,
-                "error converting {} to Timestamp, {}",
-                s,
-                msg
+                format!("error converting {} to Timestamp, {}", s, msg),
             )
         };
 


### PR DESCRIPTION
Built on top of https://github.com/Levana-Protocol/levana-perps/pull/963