### PR TITLE
contracts: Remove perp_error_data macro

### DIFF
--- a/packages/perpswap/src/error.rs
+++ b/packages/perpswap/src/error.rs
@@ -104,19 +104,6 @@ pub enum ErrorDomain {
     SimpleOracle,
 }
 
-/// Generate a [PerpError] value with additional optional data
-#[macro_export]
-macro_rules! perp_error_data {
-    ($id:expr, $domain:expr, $data:expr, $($t:tt)*) => {{
-        $crate::error::PerpError {
-            id: $id,
-            domain: $domain,
-            description: format!($($t)*),
-            data: Some($data),
-        }
-    }};
-}
-
 /// Generate a [PerpError] and then wrap it up in an anyhow error
 #[macro_export]
 macro_rules! perp_anyhow {

--- a/packages/perpswap/src/prelude.rs
+++ b/packages/perpswap/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::{
     auth::*,
     storage::{external_map_has, load_external_item, load_external_map},
 };
-pub use crate::{error::*, perp_anyhow, perp_anyhow_data, perp_ensure, perp_error_data};
+pub use crate::{error::*, perp_anyhow, perp_anyhow_data, perp_ensure};
 
 pub use anyhow::{anyhow, bail, Context, Result};
 pub use cosmwasm_schema::cw_serde;


### PR DESCRIPTION
Surprisingly this macro didn't have a single usage site.