### PR TITLE
contracts: Remove perp_anyhow_data macro

### DIFF
--- a/contracts/faucet/src/state/faucet.rs
+++ b/contracts/faucet/src/state/faucet.rs
@@ -92,13 +92,15 @@ impl State<'_> {
         // tap or not.
         self.validate_tap_faucet_error(store, recipient, assets)?
             .map_err(|e| match e {
-                FaucetError::TooSoon { wait_secs } => perp_anyhow_data!(
-                    ErrorId::Exceeded,
-                    ErrorDomain::Faucet,
-                    e,
-                    "You can tap the faucet again in {}",
-                    PrettyTimeRemaining(wait_secs),
-                ),
+                FaucetError::TooSoon { wait_secs } => anyhow!(PerpError {
+                    id: ErrorId::Exceeded,
+                    domain: ErrorDomain::Faucet,
+                    description: format!(
+                        "You can tap the faucet again in {}",
+                        PrettyTimeRemaining(wait_secs)
+                    ),
+                    data: Some(e)
+                }),
                 FaucetError::AlreadyTapped { cw20: _ } => perp_anyhow!(
                     ErrorId::Exceeded,
                     ErrorDomain::Faucet,

--- a/packages/perpswap/src/error.rs
+++ b/packages/perpswap/src/error.rs
@@ -117,19 +117,6 @@ macro_rules! perp_anyhow {
     }};
 }
 
-/// Like [perp_anyhow] but accepts optional extra data
-#[macro_export]
-macro_rules! perp_anyhow_data {
-    ($id:expr, $domain:expr, $data:expr, $($t:tt)*) => {{
-        anyhow::Error::new($crate::error::PerpError {
-            id: $id,
-            domain: $domain,
-            description: format!($($t)*),
-            data: Some($data),
-        })
-    }};
-}
-
 impl<T: Serialize> fmt::Display for PerpError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/packages/perpswap/src/prelude.rs
+++ b/packages/perpswap/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::{
     auth::*,
     storage::{external_map_has, load_external_item, load_external_map},
 };
-pub use crate::{error::*, perp_anyhow, perp_anyhow_data};
+pub use crate::{error::*, perp_anyhow};
 
 pub use anyhow::{anyhow, bail, Context, Result};
 pub use cosmwasm_schema::cw_serde;

--- a/packages/perpswap/src/time.rs
+++ b/packages/perpswap/src/time.rs
@@ -101,18 +101,22 @@ impl Timestamp {
             rhs: Timestamp,
             desc: String,
         }
+        let data = Data {
+            lhs: self,
+            rhs,
+            desc: desc.to_owned(),
+        };
         match self.0.checked_sub(rhs.0) {
             Some(x) => Ok(Duration(x)),
-            None => Err(perp_anyhow_data!(
-                ErrorId::TimestampSubtractUnderflow,
-                ErrorDomain::Default,
-                Data {
-                    lhs: self,
-                    rhs,
-                    desc: desc.to_owned()
-                },
-                "Invalid timestamp subtraction during. Action: {desc}. Values: {self} - {rhs}"
-            )),
+            None => Err(anyhow!(PerpError {
+                id: ErrorId::TimestampSubtractUnderflow,
+                domain: ErrorDomain::Default,
+                description: format!(
+                    "Invalid timestamp subtraction during. Action: {desc}. Values: {} - {}",
+                    data.lhs, data.rhs
+                ),
+                data: Some(data),
+            })),
         }
     }
 


### PR DESCRIPTION
Similar change as before, done in a backward compatible way:

`perp_anyhow_data!(PerpError{..})` gets expanded to `anyhow::Error(PerpError)`

which is equivalent to

`anyhow!(PerpError{})` gets expanded to `anyhow::Error(PerpError)`