### PR TITLE
perp-4320 | add a claim_yield field to the withdraw message

### DIFF
--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -379,7 +379,13 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> R
             state.reinvest_yield(&mut ctx, &info.sender, amount, stake_to_xlp)?;
         }
 
-        ExecuteMsg::WithdrawLiquidity { lp_amount } => {
+        ExecuteMsg::WithdrawLiquidity {
+            lp_amount,
+            claim_yield,
+        } => {
+            if claim_yield {
+                state.liquidity_claim_yield(&mut ctx, &info.sender, true)?;
+            }
             state.liquidity_withdraw(&mut ctx, &info.sender, lp_amount)?;
         }
 

--- a/packages/multi_test/src/market_wrapper.rs
+++ b/packages/multi_test/src/market_wrapper.rs
@@ -1142,12 +1142,23 @@ impl PerpsMarket {
                             .context("exec_withdraw_liquidity")?,
                     ),
                 },
+                claim_yield: false,
             },
         )
     }
 
     pub fn exec_claim_yield(&self, addr: &Addr) -> Result<AppResponse> {
         self.exec(addr, &MarketExecuteMsg::ClaimYield {})
+    }
+
+    pub fn exec_claim_yield_and_withdraw(&self, addr: &Addr) -> Result<AppResponse> {
+        self.exec(
+            addr,
+            &MarketExecuteMsg::WithdrawLiquidity {
+                lp_amount: None,
+                claim_yield: true,
+            },
+        )
     }
 
     pub fn exec_mint_and_deposit_liquidity(

--- a/packages/multi_test/tests/multi_test/wrong_token.rs
+++ b/packages/multi_test/tests/multi_test/wrong_token.rs
@@ -86,7 +86,10 @@ fn unneeded_funds() {
     market
         .exec_funds(
             &trader,
-            &MarketExecuteMsg::WithdrawLiquidity { lp_amount: None },
+            &MarketExecuteMsg::WithdrawLiquidity {
+                lp_amount: None,
+                claim_yield: false,
+            },
             "10".parse().unwrap(),
         )
         .unwrap_err();

--- a/packages/perps-exes/src/contracts/market.rs
+++ b/packages/perps-exes/src/contracts/market.rs
@@ -158,6 +158,7 @@ impl MarketContract {
                 vec![],
                 &MarketExecuteMsg::WithdrawLiquidity {
                     lp_amount: Some(lp_tokens),
+                    claim_yield: false,
                 },
             )
             .await

--- a/packages/perpswap/src/contracts/market/entry.rs
+++ b/packages/perpswap/src/contracts/market/entry.rs
@@ -286,6 +286,9 @@ pub enum ExecuteMsg {
     WithdrawLiquidity {
         /// Amount of LP tokens to burn
         lp_amount: Option<NonZero<LpToken>>,
+        /// Claim yield as well?
+        #[serde(default)]
+        claim_yield: bool,
     },
 
     /// Claims accrued yield based on LP share allocation
@@ -1308,6 +1311,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ExecuteMsg {
             }),
             14 => Ok(ExecuteMsg::WithdrawLiquidity {
                 lp_amount: u.arbitrary()?,
+                claim_yield: false,
             }),
             15 => Ok(ExecuteMsg::ClaimYield {}),
             16 => Ok(ExecuteMsg::StakeLp {


### PR DESCRIPTION
CC @lvn-skate-dragon with this change to the contracts, claim-and-withdraw can now be a single message: `{"withdraw_liquidity":{"lp_amount":SOME_VALUE,"claim_yield":true}}`.