### PR TITLE
Use buildx for companion ARM64 images

### DIFF
--- a/.github/workflows/companion.yaml
+++ b/.github/workflows/companion.yaml
@@ -41,7 +41,8 @@ jobs:
           workspaces: |
             .
       - name: Dependencies
-        run: sudo apt install musl-tools -y
+        run: |
+          sudo apt install musl-tools qemu-user-static binfmt-support -y
       - name: Build companion binary
         run: just cargo-companion-release-arm
       - name: Build image

--- a/justfile
+++ b/justfile
@@ -152,7 +152,7 @@ cargo-companion-release-arm:
 build-companion-image:
 	cp ./packages/perps-exes/assets/mainnet-factories.toml .ci/companion/
 	cp target/aarch64-unknown-linux-musl/release/perps-companion .ci/companion
-	cd .ci/companion && docker image build . -f Dockerfile -t ghcr.io/levana-protocol/levana-perps/companion:{{GIT_SHA}} --platform linux/arm64
+	cd .ci/companion && docker buildx build . --file Dockerfile -t ghcr.io/levana-protocol/levana-perps/companion:{{GIT_SHA}} --platform linux/arm64
 
 # Push bots docker image
 push-companion-image:


### PR DESCRIPTION
Built on top of ci-cross branch whose PR is separately sent.