### PR TITLE
PERP-4340 | Update description for perps-deploy dockerfile

### DIFF
--- a/.ci/perps-deploy/Dockerfile
+++ b/.ci/perps-deploy/Dockerfile
@@ -8,6 +8,6 @@ COPY --chmod=755 --chown=1000 perps-deploy /usr/bin/perps-deploy
 
 WORKDIR /app
 
-ENTRYPOINT [ "/usr/bin/health-check", "--task-output-timeout", "90000", "--app-description", "Perps Deploy (Github cron job)", "--can-exit", "perps-deploy" ]
+ENTRYPOINT [ "/usr/bin/health-check", "--task-output-timeout", "90000", "--app-description", "Perps Deploy", "--can-exit", "perps-deploy" ]
 
 CMD [ "util", "top-traders" ]


### PR DESCRIPTION
[PERP-4340](https://phobosfinance.atlassian.net/browse/PERP-4340)
@snoyberg I forgot to add this change for the previous PR. Making this PR to update the app description which was saying about the "github cron job".

[PERP-4340]: https://phobosfinance.atlassian.net/browse/PERP-4340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ