### PR TITLE
Revert "Treat null in CLOSE_ALL_POSITIONS as not wound down"

### DIFF
--- a/packages/perps-exes/src/contracts/market.rs
+++ b/packages/perps-exes/src/contracts/market.rs
@@ -750,7 +750,7 @@ impl MarketContract {
         self.0
             .query_raw(CLOSE_ALL_POSITIONS)
             .await
-            .map(|v| !v.is_empty() && v != b"null")
+            .map(|v| !v.is_empty())
     }
 
     pub async fn get_deferred_exec(&self, id: DeferredExecId) -> Result<GetDeferredExecResp> {


### PR DESCRIPTION
This reverts commit dd080c3c925d36e40bbfd3cdeaaf386a1a20c63d.

Reasoning: the `null` value actually means "Item has been set" which means we _did_ initiate a "close all positions." The reason we had trouble on osmoci is that the market was not wound down correctly: it closed all positions without blocking the ability to open positions in the future. We could consider modifying the contracts to make that case impossible, but for now I'd rather simply revert the code to the working version since this is a testnet-only fake market problem.