### PR TITLE
PERP-4427 | Typo from copy-trading

### DIFF
--- a/contracts/copy_trading/src/types.rs
+++ b/contracts/copy_trading/src/types.rs
@@ -325,7 +325,7 @@ impl DecQueuePosition {
 impl IncQueuePosition {
     pub fn into_queue_item(self, id: IncQueuePositionId) -> QueueItemStatus {
         QueueItemStatus {
-            item: QueueItem::IncCollaleteral {
+            item: QueueItem::IncCollateral {
                 item: self.item,
                 id,
             },

--- a/packages/multi_test/tests/multi_test/copy_trading.rs
+++ b/packages/multi_test/tests/multi_test/copy_trading.rs
@@ -46,7 +46,7 @@ fn deposit() {
     assert_eq!(
         item,
         &QueueItemStatus {
-            item: QueueItem::IncCollaleteral {
+            item: QueueItem::IncCollateral {
                 item: IncQueueItem::Deposit {
                     funds: NonZero::new(Collateral::from_str("100").unwrap()).unwrap(),
                     token,

--- a/packages/perpswap/src/contracts/copy_trading.rs
+++ b/packages/perpswap/src/contracts/copy_trading.rs
@@ -344,7 +344,7 @@ pub enum FailedReason {
 #[serde(rename_all = "snake_case")]
 pub enum QueueItem {
     /// Item that will lead to increase or no change of collateral
-    IncCollaleteral {
+    IncCollateral {
         /// Item type
         item: IncQueueItem,
         /// Queue position id


### PR DESCRIPTION
[PERP-4427](https://phobosfinance.atlassian.net/browse/PERP-4427)

[PERP-4427]: https://phobosfinance.atlassian.net/browse/PERP-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ