### PR TITLE
PERP-4412 | Testing mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,6 +3346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +3462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3764,6 +3783,7 @@ dependencies = [
  "itertools 0.13.0",
  "levana_perpswap_cosmos",
  "levana_perpswap_multi_test",
+ "mimalloc",
  "mime",
  "once_cell",
  "parking_lot",

--- a/packages/perps-exes/Cargo.toml
+++ b/packages/perps-exes/Cargo.toml
@@ -80,6 +80,7 @@ figment = { version = "0.10.19", features = ["env", "yaml", "toml"] }
 toml = "0.8.19"
 backon = "1.2.0"
 comfy-table = "7.1.1"
+mimalloc = "0.1.43"
 
 [features]
 default = []

--- a/packages/perps-exes/src/bin/perps-bots/main.rs
+++ b/packages/perps-exes/src/bin/perps-bots/main.rs
@@ -14,6 +14,9 @@ mod util;
 pub(crate) mod wallet_manager;
 pub(crate) mod watcher;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<()> {
     Pid1Settings::new().enable_log(true).launch()?;
     main_inner()

--- a/packages/perps-exes/src/bin/perps-companion/main.rs
+++ b/packages/perps-exes/src/bin/perps-companion/main.rs
@@ -12,6 +12,9 @@ use clap::Parser;
 use cli::Opt;
 use pid1::Pid1Settings;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     main_inner().await

--- a/packages/perps-exes/src/bin/perps-deploy/main.rs
+++ b/packages/perps-exes/src/bin/perps-deploy/main.rs
@@ -20,6 +20,9 @@ mod tracker;
 mod util;
 mod util_cmd;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     main_inner().await

--- a/packages/perps-exes/src/bin/perps-market-params/main.rs
+++ b/packages/perps-exes/src/bin/perps-market-params/main.rs
@@ -22,6 +22,9 @@ mod s3;
 mod slack;
 mod web;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<()> {
     let opt = Opt::parse();
     opt.init_logger()?;


### PR DESCRIPTION
Testing mimalloc on:
* Perps Bots
* Perps Companion
* Perps Deploy
* Perps Market Params

mimalloc is explicitly set as Rust’s allocator