### PR TITLE
PERP-4462 | additional validations for config updates

### DIFF
--- a/contracts/copy_trading/src/execute.rs
+++ b/contracts/copy_trading/src/execute.rs
@@ -207,6 +207,7 @@ fn leader_update_config(
             .add_attribute("old-name", state.config.name.to_string())
             .add_attribute("new-name", name);
     }
+    config.check()?;
     crate::state::CONFIG.save(storage, &config)?;
     Ok(Response::new().add_event(event))
 }

--- a/contracts/countertrade/src/execute.rs
+++ b/contracts/countertrade/src/execute.rs
@@ -321,6 +321,7 @@ fn update_config(
         event = event.add_attribute("new-stop-loss-factor", stop_loss_factor.to_string());
         state.config.stop_loss_factor = stop_loss_factor;
     }
+    state.config.check()?;
 
     crate::state::CONFIG.save(storage, &state.config)?;
 

--- a/packages/perpswap/src/contracts/market/config.rs
+++ b/packages/perpswap/src/contracts/market/config.rs
@@ -326,6 +326,22 @@ impl Config {
             bail!(PerpError::market(ErrorId::Config, msg))
         }
 
+        if self.exposure_margin_ratio >= Decimal256::one() {
+            let msg = format!(
+                "Exposure margin ratio ({}) must be less than 1",
+                self.exposure_margin_ratio
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
+        }
+
+        if self.referral_reward_ratio >= Decimal256::one() {
+            let msg = format!(
+                "Referral reward ratio ({}) must be less than 1",
+                self.referral_reward_ratio
+            );
+            bail!(PerpError::market(ErrorId::Config, msg))
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
[PERP-4462](https://phobosfinance.atlassian.net/browse/PERP-4462)

https://slack-files.com/files-pri-safe/TBBUPFK9D-F08HEA2UWG2/levana_-_security_code_review_levana_updates_v0.1.pdf?c=1741859330-e12c12b6a643bd66

The copy_trading and countertrade contracts already have `check` method for their configs which is used for initialize.
Just reusing these method for those two contracts' validations.

[PERP-4462]: https://phobosfinance.atlassian.net/browse/PERP-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ