### PR TITLE
Address the no liquidity in pool error

### DIFF
--- a/contracts/market/src/state/liquidity.rs
+++ b/contracts/market/src/state/liquidity.rs
@@ -517,6 +517,38 @@ impl State<'_> {
     ) -> Result<()> {
         self.update_accrued_yield(ctx, lp_addr)?;
         let mut addr_stats = self.load_liquidity_stats_addr(ctx.storage, lp_addr)?;
+        let liquidity_stats = self.load_liquidity_stats(ctx.storage)?;
+
+        if liquidity_stats.total_collateral()?.is_zero() {
+            let total_yield = addr_stats.total_yield()?;
+            let mut claimed_yield = Collateral::zero();
+            if let Some(total_yield) = NonZero::new(total_yield) {
+                claimed_yield = self.register_lp_claimed_yield_capped(ctx, total_yield)?;
+                if let Some(claimed_yield) = NonZero::new(claimed_yield) {
+                    self.add_token_transfer_msg(ctx, lp_addr, claimed_yield)?;
+                }
+            }
+
+            addr_stats.lp = LpToken::zero();
+            addr_stats.xlp = LpToken::zero();
+            addr_stats.unstaking = None;
+            addr_stats.cooldown_ends = None;
+            addr_stats.last_accrue_key = self.latest_yield_per_token(ctx.storage)?.0;
+            addr_stats.lp_accrued_yield = Collateral::zero();
+            addr_stats.xlp_accrued_yield = Collateral::zero();
+            addr_stats.crank_rewards = Collateral::zero();
+            addr_stats.referrer_rewards = Collateral::zero();
+            self.save_liquidity_stats_addr(ctx.storage, lp_addr, &addr_stats)?;
+
+            ctx.response_mut().add_event(
+                Event::new("force-withdraw-liquidity")
+                    .add_attribute("lp-addr", lp_addr.as_str())
+                    .add_attribute("yield", claimed_yield.to_string())
+                    .add_attribute("withdrawn-funds", Collateral::zero().to_string()),
+            );
+
+            return Ok(());
+        }
 
         let old_unstaking = addr_stats.unstaking.take();
         if let Some(old_unstaking) = old_unstaking {
@@ -562,7 +594,7 @@ impl State<'_> {
             }
         };
 
-        let mut liquidity_stats = self.load_liquidity_stats(ctx.storage)?;
+        let mut liquidity_stats = liquidity_stats;
         let liquidity_to_return = liquidity_stats.lp_to_collateral_non_zero(shares_to_withdraw)?;
         anyhow::ensure!(
             liquidity_to_return.raw() <= liquidity_stats.unlocked,

--- a/packages/multi_test/tests/multi_test/liquidity.rs
+++ b/packages/multi_test/tests/multi_test/liquidity.rs
@@ -822,7 +822,20 @@ fn drain_all_liquidity_perp_705() {
         .exec_mint_and_deposit_liquidity(lp, Number::from(5u64))
         .unwrap_err();
 
-    // Now crank till all balances are reset
+    // ForceWithdrawAll is allowed during shutdown/reset and should clear the
+    // stale LP balance without trying to convert shares against zero collateral.
+    market
+        .exec(
+            &crank,
+            &perpswap::contracts::market::entry::ExecuteMsg::ForceWithdrawAll { limit: Some(1) },
+        )
+        .unwrap();
+    let info = market.query_lp_info(lp).unwrap();
+    assert_eq!(info.lp_amount, LpToken::zero());
+    assert_eq!(info.xlp_amount, LpToken::zero());
+    assert_eq!(info.available_yield, Collateral::zero());
+
+    // Now crank till the reset marker is cleared.
     market.exec_crank_till_finished(&crank).unwrap();
 
     // Ensure we have no liquidity left
@@ -837,9 +850,8 @@ fn drain_all_liquidity_perp_705() {
         }
     );
 
-    // We should have a small amount of borrow fee received from the previous generation
-    market.exec_claim_yield(lp).unwrap();
-    // But as usual it should fail the second time through
+    // ForceWithdrawAll claimed any remaining capped yield, so a separate yield
+    // claim should fail.
     market.exec_claim_yield(lp).unwrap_err();
 
     // Ensure we can deposit liquidity again


### PR DESCRIPTION
This is occurring right now when force withdrawing the wstETH_USD market on Neutron mainnet. Not sure this is the right solution or not.

2026-06-18T01:06:45.546822Z  INFO perps_deploy::mainnet::force_withdraw_all: Force withdrawing all funds in wstETH_USD
Error: ForceWithdrawAll simulation failed for wstETH_USD

Caused by:
    0: On connection to https://grpc-lb.neutron.org/, while performing:
       simulating transaction: Message 0: neutron1e2r98hpf3eer8pfpcrsprmrx5vpfq8jpc2r4tg executing contract neutron1lkm345465c0gy0m0tehq8h0kkkfdcttr039wejs053mdv27pzndqw3hnv7 with message: {"force_withdraw_all":{"limit":null}}
       Failed to execute message: status: Unknown, message: "failed to execute message; message index: 0: LiquidityStats::lp_to_collateral: no liquidity is in the pool: execute wasm contract failed [CosmWasm/wasmd@v0.61.0/x/wasm/keeper/keeper.go:457] with gas used: '244932'", details: [], metadata: MetadataMap { headers: {"date": "Thu, 18 Jun 2026 01:06:45 GMT", "content-type": "application/grpc", "via": "2.0 Caddy", "x-cosmos-block-height": "59391332", "cf-cache-status": "DYNAMIC", "server": "cloudflare", "cf-ray": "a0d664abacafb546-LHR", "alt-svc": "h3=\":443\"; ma=86400"} }